### PR TITLE
Changes to upgrade/update commands to prevent segfault.

### DIFF
--- a/zulu-init
+++ b/zulu-init
@@ -510,6 +510,13 @@ function _zulu_load_commands() {
   done
 }
 
+function _zulu_load_packages() {
+  # Source files in the init directory
+  for f in $(find "$base/init"); do
+    source $f
+  done
+}
+
 function _zulu_init() {
   local base=${ZULU_DIR:-"${ZDOTDIR:-$HOME}/.zulu"}
   local config=${ZULU_CONFIG_DIR:-"${ZDOTDIR:-$HOME}/.config/zulu"}
@@ -518,11 +525,7 @@ function _zulu_init() {
   typeset -gU cdpath fpath mailpath path
 
   _zulu_load_commands
-
-  # Source files in the init directory
-  for f in $(find "$base/init"); do
-    source $f
-  done
+  _zulu_load_packages
 
   # Populate $PATH and $fpath
   zulu path reset

--- a/zulu-self-update
+++ b/zulu-self-update
@@ -50,5 +50,5 @@ function _zulu_self-update() {
     echo "$out"
   fi
 
-  zulu init
+  _zulu_load_commands
 }

--- a/zulu-self-update
+++ b/zulu-self-update
@@ -16,7 +16,7 @@ function _zulu_self-update_usage() {
 ###
 function _zulu_self-update_core() {
   cd $core
-  git fetch origin && git merge origin/master
+  git fetch origin && git rebase origin
   cd -
 }
 

--- a/zulu-update
+++ b/zulu-update
@@ -16,7 +16,7 @@ function _zulu_update_usage() {
 ###
 function _zulu_update_index() {
   cd $index
-  git fetch origin && git merge origin/master
+  git fetch origin && git rebase origin
   cd -
 }
 

--- a/zulu-upgrade
+++ b/zulu-upgrade
@@ -18,7 +18,7 @@ function _zulu_upgrade_package() {
 
   # Pull from the repository
   cd "$base/packages/$package"
-  git fetch origin && git merge origin/master
+  git fetch origin && git rebase origin
 }
 
 ###

--- a/zulu-upgrade
+++ b/zulu-upgrade
@@ -19,15 +19,13 @@ function _zulu_upgrade_package() {
   # Pull from the repository
   cd "$base/packages/$package"
   git fetch origin && git merge origin/master
-
-  return $?
 }
 
 ###
 # Zulu command to handle package upgrades
 ###
 function _zulu_upgrade() {
-  local base index packages out
+  local base index packages out count down to_update=()
 
   # Parse options
   zparseopts -D h=help -help=help
@@ -56,22 +54,56 @@ function _zulu_upgrade() {
   fi
 
   # Do a second loop, to do the actual upgrade
+  local i=1
   for package in "$packages[@]"; do
-    # Unlink package first
-    zulu unlink $package
+    cd "$base/packages/$package"
 
-    # Upgrade the package
-    _zulu_spinner_start "Upgrading $package..."
-    out=$(_zulu_upgrade_package "$package" 2>&1)
+    if command git rev-parse --abbrev-ref @'{u}' &>/dev/null; then
+      count="$(command git rev-list --left-right --count HEAD...@'{u}' 2>/dev/null)"
 
-    if [ $? -eq 0 ]; then
-      _zulu_spinner_stop
-      echo "$(color green '✔') Finished upgrading $package        "
-      zulu link $package
-    else
-      _zulu_spinner_stop
-      echo "$(color red '✘') Error upgrading $package        "
-      echo "$out"
+      down="$count[(w)2]"
+
+      if [[ $down > 0 ]]; then
+        to_update[$i]="$package"
+        i+=1
+      fi
     fi
   done
+
+  if [[ ${#to_update} -eq 0 ]]; then
+    echo $(color green 'Nothing to upgrade')
+    return 0
+  fi
+
+  echo $(color yellow 'The following packages will be upgraded')
+  echo "$to_update[@]"
+  echo $(color yellow bold 'Continue (y|N)')
+  read -rs -k 1 input
+
+  case $input in
+    y)
+      for package in "$to_update[@]"; do
+        # Unlink package first
+        zulu unlink $package
+
+        # Upgrade the package
+        _zulu_spinner_start "Upgrading $package..."
+        out=$(_zulu_upgrade_package "$package" 2>&1)
+
+        if [ $? -eq 0 ]; then
+          _zulu_spinner_stop
+          echo "$(color green '✔') Finished upgrading $package        "
+          zulu link $package
+        else
+          _zulu_spinner_stop
+          echo "$(color red '✘') Error upgrading $package        "
+          echo "$out"
+        fi
+      done
+      ;;
+    *)
+      echo $(color red 'Upgrade cancelled')
+      return 1
+      ;;
+  esac
 }


### PR DESCRIPTION
Sourcing the entire environment unnecessarily caused the current shell to
exit ungracefully. Fixed by only reloading those elements which are
necessary.

Also cleaned up the upgrade command in the process by only running the rebase
on packages which need upgrading, and asking for user confirmation before
doing so.

Closes issue #1
