### PR TITLE
Move entries in index repository into a subfolder

### DIFF
--- a/commands/info
+++ b/commands/info
@@ -52,7 +52,7 @@ function _zulu_info() {
   # Set up some variables
   base=${ZULU_DIR:-"${ZDOTDIR:-$HOME}/.zulu"}
   config=${ZULU_CONFIG_DIR:-"${ZDOTDIR:-$HOME}/.config/zulu"}
-  index="${base}/index"
+  index="${base}/index/packages"
 
   if [[ ! -f "$index/$package" ]]; then
     echo $(color red "Package '$package' is not in the index")

--- a/commands/install
+++ b/commands/install
@@ -75,7 +75,7 @@ function _zulu_install() {
   # Set up some variables
   base=${ZULU_DIR:-"${ZDOTDIR:-$HOME}/.zulu"}
   config=${ZULU_CONFIG_DIR:-"${ZDOTDIR:-$HOME}/.config/zulu"}
-  index="${base}/index"
+  index="${base}/index/packages"
 
   packages=($@)
   packagefile="$config/packages"

--- a/commands/link
+++ b/commands/link
@@ -24,7 +24,7 @@ function _zulu_link() {
 
   base=${ZULU_DIR:-"${ZDOTDIR:-$HOME}/.zulu"}
   config=${ZULU_CONFIG_DIR:-"${ZDOTDIR:-$HOME}/.config/zulu"}
-  index="$base/index"
+  index="$base/index/packages"
 
   package="$1"
 

--- a/commands/list
+++ b/commands/list
@@ -22,9 +22,9 @@ function _zulu_list_all() {
 
   base=${ZULU_DIR:-"${ZDOTDIR:-$HOME}/.zulu"}
   config=${ZULU_CONFIG_DIR:-"${ZDOTDIR:-$HOME}/.config/zulu"}
-  index="$base/index"
+  index="$base/index/packages"
 
-  for package in $(/bin/ls $index); do
+  for package in $(/bin/ls $index | grep -v '.md'); do
     if [[ -n $simple ]]; then
       name="$package"
       lim=30
@@ -57,7 +57,7 @@ function _zulu_list_installed() {
 
   base=${ZULU_DIR:-"${ZDOTDIR:-$HOME}/.zulu"}
   config=${ZULU_CONFIG_DIR:-"${ZDOTDIR:-$HOME}/.config/zulu"}
-  index="$base/index"
+  index="$base/index/packages"
 
   for package in $(/bin/ls "$base/packages"); do
     if [[ -n $describe ]]; then
@@ -80,9 +80,9 @@ function _zulu_list_not_installed() {
 
   base=${ZULU_DIR:-"${ZDOTDIR:-$HOME}/.zulu"}
   config=${ZULU_CONFIG_DIR:-"${ZDOTDIR:-$HOME}/.config/zulu"}
-  index="$base/index"
+  index="$base/index/packages"
 
-  for package in $(/bin/ls $index); do
+  for package in $(/bin/ls $index | grep -v '.md'); do
     if [[ ! -d "$base/packages/$package" ]]; then
       if [[ -n $describe ]]; then
         json="$(cat $index/$package)"

--- a/commands/search
+++ b/commands/search
@@ -26,7 +26,7 @@ function _zulu_search() {
   # Set up some variables
   base=${ZULU_DIR:-"${ZDOTDIR:-$HOME}/.zulu"}
   config=${ZULU_CONFIG_DIR:-"${ZDOTDIR:-$HOME}/.config/zulu"}
-  index="${base}/index"
+  index="${base}/index/packages"
 
   results="$(zulu list --all | grep -i $term)"
   echo "$results"

--- a/commands/uninstall
+++ b/commands/uninstall
@@ -54,7 +54,7 @@ function _zulu_uninstall() {
   # Set up some variables
   base=${ZULU_DIR:-"${ZDOTDIR:-$HOME}/.zulu"}
   config_dir=${ZULU_CONFIG_DIR:-"${ZDOTDIR:-$HOME}/.config/zulu"}
-  index="${base}/index"
+  index="${base}/index/packages"
 
   # If no context is passed, output the contents of the pathfile
   if [[ "$1" = "" ]]; then

--- a/commands/unlink
+++ b/commands/unlink
@@ -24,7 +24,7 @@ function _zulu_unlink() {
 
   base=${ZULU_DIR:-"${ZDOTDIR:-$HOME}/.zulu"}
   config_dir=${ZULU_CONFIG_DIR:-"${ZDOTDIR:-$HOME}/.config/zulu"}
-  index="$base/index"
+  index="$base/index/packages"
 
   package="$1"
 

--- a/commands/upgrade
+++ b/commands/upgrade
@@ -24,7 +24,7 @@ function _zulu_upgrade_package() {
   cd "$base/packages/$package"
   git fetch origin && git rebase origin && git submodule update --init --recursive
 
-  json=$(cat "${ZULU_DIR:-"$HOME/.zulu"}/index/$package")
+  json=$(cat "$index/$package")
   post_install=$(jsonval $json 'postinstall')
   if [[ -n $post_install ]]; then
     "$post_install"
@@ -53,7 +53,7 @@ function _zulu_upgrade() {
   # Set up some variables
   base=${ZULU_DIR:-"${ZDOTDIR:-$HOME}/.zulu"}
   config=${ZULU_CONFIG_DIR:-"${ZDOTDIR:-$HOME}/.config/zulu"}
-  index="${base}/index"
+  index="${base}/index/packages"
 
   _zulu_spinner_start "Checking for updates..."
 


### PR DESCRIPTION
Also, update all necessary commands to use the new location

Allows meta to be included in the top level of the repository, without
the meta files appearing in the package lists.

(Will need to checkout the `version-1.0.x` branch of the index repository to use when testing)
