### PR TITLE
Fix history setup on init

### DIFF
--- a/commands/init
+++ b/commands/init
@@ -184,6 +184,9 @@ function _zulu_init_setup_history() {
     # Source module files.
     [[ -f "$base/init/zsh-history-substring-search.zsh" ]] || return 1
 
+    zle -N history-substring-search-up
+    zle -N history-substring-search-down
+
     #
     # Search
     #
@@ -565,11 +568,13 @@ function _zulu_init() {
 
   # Set up the environment
   _zulu_init_setup_key_bindings
-  _zulu_init_setup_history
   _zulu_init_setup_completion
 
   # Load installed packages
   _zulu_load_packages
+
+  # Set up history
+  _zulu_init_setup_history
 
   # Load aliases
   zulu alias load


### PR DESCRIPTION
`history-substring-search` function failed to work due to the widget
being sourced after it was attempted to bind it to a key. Also, the key
bindings themselves were failing because the widgets were not registered
with ZLE.

Fix #29