### PR TITLE
Add func command

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ mkdir -p ${ZULU_DIR}/{bin,share,init,packages}
 touch ${ZULU_DIR}/{bin,share,init,packages}/.gitkeep
 
 # Create config directory
-mkdir -p ${ZULU_CONFIG_DIR}
+mkdir -p "${ZULU_CONFIG_DIR}/functions"
 
 # Clone the core and index repositories
 git clone https://github.com/zulu-zsh/zulu ${ZULU_DIR}/core
@@ -150,7 +150,9 @@ zulu path
 
 ### Managing aliases
 
-Zulu can also manage your aliases.
+Zulu can also manage your aliases. Using the `zulu alias` commands will add or
+remove the alias, loading it into your existing session and ensuring it is
+sourced at the next initialisation in a single command.
 
 ```sh
 # Add an alias
@@ -161,6 +163,27 @@ zulu alias rm l
 
 # List aliases
 zulu alias
+```
+
+### Managing functions
+
+Zulu can manage user functions. Using the `zulu func` commands will allow you to
+add new functions, creating some boilerplate and opening the resulting file in
+your `$EDITOR` for you to add the function body. When you save, the function is
+immediately sourced, and will be sourced in every future session automatically.
+
+```sh
+# Add a function
+zulu func add myawesomefunction
+
+# Edit a function
+zulu func edit myawesomefunction
+
+# Remove a function
+zulu func rm myawesomefunction
+
+# List functions
+zulu func
 ```
 
 ### Choosing a theme

--- a/README.md
+++ b/README.md
@@ -168,7 +168,10 @@ zulu alias
 Zulu can switch themes for you, and will load the chosen theme on next login.
 
 ```sh
+# Install and select a theme
 zulu install filthy
+
+# Select an installed theme
 zulu theme filthy
 ```
 

--- a/commands/func
+++ b/commands/func
@@ -1,0 +1,132 @@
+#!/usr/bin/env zsh
+
+###
+# Output usage information
+###
+function _zulu_func_usage() {
+  echo $(_zulu_color yellow "Usage:")
+  echo "  zulu func <context>"
+  echo
+  echo $(_zulu_color yellow "Contexts:")
+  echo "  add <function>    Add a function"
+  echo "  edit <function>   Edit a function"
+  echo "  rm <function>     Remove a function"
+  echo "  load              Load all functions from functions directory"
+}
+
+###
+# Add a function
+###
+_zulu_func_add() {
+  local existing func cmd
+
+  func="$1"
+
+  if [[ -f "$funcdir/$func" ]]; then
+    echo $(_zulu_color red "Function '$func' already exists")
+    return 1
+  fi
+
+  echo "#!/usr/bin/env zsh
+
+(( \$+functions[$func] )) || function $func() {
+
+}" > "$funcdir/$func"
+
+  $EDITOR "$funcdir/$func"
+
+  zulu func load
+  return
+}
+
+###
+# Add a function
+###
+_zulu_func_edit() {
+  local existing func cmd
+
+  func="$1"
+
+  if [[ ! -f "$funcdir/$func" ]]; then
+    echo $(_zulu_color red "Function '$func' does not exist")
+    return 1
+  fi
+
+  $EDITOR "$funcdir/$func"
+
+  zulu func load
+  return
+}
+
+###
+# Remove a function
+###
+_zulu_func_rm() {
+  local existing func
+
+  func="$1"
+
+  if [[ ! -f "$funcdir/$func" ]]; then
+    echo $(_zulu_color red "Function '$alias' does not exist")
+    return 1
+  fi
+
+  unfunction $func
+  rm "$funcdir/$func"
+  zulu func load
+  return
+}
+
+###
+# Load aliases
+###
+_zulu_func_load() {
+  for f in $(ls $funcdir); do
+    (( $+functions[$f] )) && unfunction $f
+    source "$funcdir/$f"
+  done
+}
+
+###
+# Zulu command to handle managing functions
+###
+function _zulu_func() {
+  local ctx base funcdir
+
+  # Parse options
+  zparseopts -D h=help -help=help
+
+  # Output help and return if requested
+  if [[ -n $help ]]; then
+    _zulu_func_usage
+    return
+  fi
+
+  if [[ -z $EDITOR ]]; then
+    echo $(_zulu_color red "The \$EDITOR environment variable must be set to use the func command")
+    return 1
+  fi
+
+  # Set up some variables
+  base=${ZULU_DIR:-"${ZDOTDIR:-$HOME}/.zulu"}
+  config=${ZULU_CONFIG_DIR:-"${ZDOTDIR:-$HOME}/.config/zulu"}
+  funcdir="${config}/functions"
+
+  # Check for and create the directory, since it will not
+  # exist in older versions of Zulu
+  if [[ ! -d "$funcdir" ]]; then
+    mkdir -p "$funcdir"
+  fi
+
+  # If no context is passed, output the contents of the aliasfile
+  if [[ "$1" = "" ]]; then
+    ls "$funcdir"
+    return
+  fi
+
+  # Get the context
+  ctx="$1"
+
+  # Call the relevant function
+  _zulu_func_${ctx} "${(@)@:2}"
+}

--- a/commands/init
+++ b/commands/init
@@ -596,8 +596,9 @@ function _zulu_init() {
   # Set up history
   _zulu_init_setup_history
 
-  # Load aliases
+  # Load aliases and functions
   zulu alias load
+  zulu func load
 
   # Autoload zsh theme
   if [[ -f "$config/theme" ]]; then

--- a/commands/link
+++ b/commands/link
@@ -61,6 +61,11 @@ function _zulu_link() {
     fi
   done
 
+  package_type=$(jsonval $json 'type')
+  if [[ $package_type = 'theme' ]]; then
+    zulu theme $package
+  fi
+
   _zulu_revolver stop
   echo "$(_zulu_color green '✔') Finished linking $package        "
 }

--- a/zulu
+++ b/zulu
@@ -22,6 +22,7 @@ function _zulu_usage() {
   echo "  info                  Show information for a package"
   echo "  search                Search the package index"
   echo "  alias <args>          Functions for adding/removing aliases"
+  echo "  func <args>           Functions for adding/removing functions"
   echo "  path <args>           Functions for adding/removing dirs from \$PATH"
   echo "  fpath <args>          Functions for adding/removing dirs from \$fpath"
   echo "  cdpath <args>         Functions for adding/removing dirs from \$cdpath"

--- a/zulu.zsh-completion
+++ b/zulu.zsh-completion
@@ -18,6 +18,7 @@ _zulu_commands=(
   'theme:Change the theme'
   'init:Reload zulu configuration'
   'alias:Functions for adding/removing aliases'
+  'func:Functions for adding/removing functions'
   'path:Functions for adding/removing directories from \$path'
   'cdpath:Functions for adding/removing directories from \$cdpath'
   'fpath:Functions for adding/removing directories from \$fpath'
@@ -57,6 +58,16 @@ _zulu_alias_commands=(
   'add:Add a new alias'
   'rm:Remove an existing alias'
   'load:Reload all aliases'
+)
+
+###
+# Commands in the func context
+###
+_zulu_func_commands=(
+  'add:Add a new function'
+  'edit:Edit an existing function'
+  'rm:Remove an existing function'
+  'load:Reload all functions'
 )
 
 ###
@@ -169,6 +180,10 @@ _zulu() {
           _arguments \
             '1: :_zulu_alias_cmds'
           ;;
+        (func)
+          _arguments \
+            '1: :_zulu_func_cmds'
+          ;;
         (fpath)
           _arguments \
             '1: :_zulu_fpath_cmds'
@@ -278,6 +293,10 @@ _zulu() {
 
 (( $+functions[_zulu_alias_cmds] )) || _zulu_alias_cmds() {
   _describe -t commands 'commands' _zulu_alias_commands "$@"
+}
+
+(( $+functions[_zulu_func_cmds] )) || _zulu_func_cmds() {
+  _describe -t commands 'commands' _zulu_func_commands "$@"
 }
 
 (( $+functions[_zulu_cmds] )) || _zulu_cmds() {


### PR DESCRIPTION
* `zulu func add myawesomefunction` - Creates a file named `myawesomefunction` with the following boilerplate code:
    ```sh
    #!/usr/bin/env zsh
    
    (( $+functions[myawesomefunction] )) || function myawesomefunction() {
    
    }
    ```
    and opens it in the users `$EDITOR`. When the editor process ends (e.g. after saving and exiting) the function is loaded into the environment immediately.
* `zulu func edit myawesomefunction` - Opens the definition for `myawesomefunction` in the users `$EDITOR`, immediately loading it when the editor process ends.
* `zulu func rm myawesomefunctoin` - Unfunctions `myawesomefunction`, and removes the definition from the functions directory.
* `zulu func load` - Unfunctions and reloads all user-defined functions.
* `zulu func` - List the names of all defined functions.

To test:

```sh
cd ~/.zulu/core
git checkout add_func_command
zulu init
zulu func add myawesomefunction
```