### PR TITLE
Improve error message if theme is not installed properly

### DIFF
--- a/commands/theme
+++ b/commands/theme
@@ -32,5 +32,14 @@ _zulu_theme() {
   # Ensure promptinit is loaded
   autoload -U promptinit && promptinit
 
-  prompt $theme
+  # Test if theme prompt function exists.
+  # If not, print a pretty warn message.
+  if which prompt_${theme}_setup >/dev/null 2>&1; then
+    prompt ${theme}
+    return
+  fi
+
+  echo $(color red "Failed to load theme '${theme}'")
+  echo "Please ensure your theme is in \$fpath and is called prompt_${theme}_setup"
+  return 1
 }


### PR DESCRIPTION
This PR prints out a nicer error message, if the theme is not installed properly. Unfortunately the `prompt` builtin does always return 0, so we have to test the existence of a (hopefully working) theme function.