### PR TITLE
Improve the way the unlink command removes links to packages

### DIFF
--- a/commands/unlink
+++ b/commands/unlink
@@ -42,14 +42,17 @@ function _zulu_unlink() {
 
   # Loop through the 'bin' and 'share' objects
   dirs=('bin' 'init' 'share')
+  local oldPWD=$PWD
   for dir in $dirs[@]; do
-    # Convert the bin/share object into an associative array
-    typeset -A files; files=($(echo $(jsonval $json $dir) | tr "," "\n" | tr ":" " "))
-
-    # Loop through each of the values in the array, the key is a file within
-    # the package, the value is the name of a symlink to create in the directory
-    for file link ("${(@kv)files}") [[ -L "$base/$dir/$link" ]] && rm "$base/$dir/$link"
+    cd "$base/$dir"
+    # Unlink any file in $dir which points to the package's source
+    ls -la "$base/$dir" | \
+      grep "$base/packages/$package/" | \
+      awk '{print $9}' | \
+      xargs rm
   done
+
+  cd $oldPWD
 
   _zulu_revolver stop
   echo "$(_zulu_color green '✔') Finished unlinking $package        "


### PR DESCRIPTION
At the moment, when `zulu unlink` is run (either alone, or as part of
`zulu uninstall`), it loops through the files in the bin, share and
index objects in the index file, and removes each one. This works while
packages are static, but causes issues when the index is updated. If a
linked file is removed from the index, when that package is
unlinked/uninstalled, the file that was removed from the index will
remain in the bin/share/init directory as zulu no longer knows about it.

This new version of the unlink command searches each of the directories
for links to the package's source, so that all links will be removed,
regardless of whether or not they are still mentioned in the index.