### PR TITLE
Allows wildcard linking

### DIFF
--- a/commands/link
+++ b/commands/link
@@ -46,9 +46,12 @@ function _zulu_link() {
     # Convert the bin/share object into an associative array
     typeset -A files; files=($(echo $(jsonval $json $dir) | tr "," "\n" | tr ":" " "))
 
+    # Continue on to the next directory if no files exist
+    [[ ${#files} -eq 0 ]] && continue
+
     # Loop through each of the values in the array, the key is a file within
     # the package, the value is the name of a symlink to create in the directory
-    for file link ("${(@kv)files}") ln -s "$root/$file" "$base/$dir/$link"
+    for file link (${(@kv)files}) ln -s $root/${~file} $base/$dir/$link
 
     # Make sure that commands to be included in bin are executable
     if [[ "$dir" = "bin" ]]; then


### PR DESCRIPTION
Allows for a glob path to be specified in the init/bin/share key of a
package's index entry, which will create individual links in the
relevant directory for any files which match the glob.

Example portion from [`completions`](https://github.com/zulu-zsh/index/tree/master/packages/completions) package:

```json
{
  "share": {"src/*": "."}
}
```