### PR TITLE
Add --depth=1 and --shallow-submodules options to the git clone when installing

### DIFF
--- a/src/commands/install.zsh
+++ b/src/commands/install.zsh
@@ -34,7 +34,7 @@ function _zulu_install_package() {
 
   # Clone the repository
   cd "$base/packages"
-  git clone --recursive $repo $package
+  git clone --recursive --depth=1 --shallow-submodules $repo $package
 
   packagefile="$config/packages"
   in_packagefile=$(cat $packagefile | grep -e '^'${package}'$')


### PR DESCRIPTION
Allows for a faster clone, particularly on busy repositories, and since Zulu is managing the package we don't need the full commit history.