### PR TITLE
Add --dev flag to zulu init

### DIFF
--- a/src/commands/init.zsh
+++ b/src/commands/init.zsh
@@ -6,6 +6,7 @@ function _zulu_init_usage() {
   echo "  -c, --check-for-update   Check for updates on startup"
   echo "  -h, --help               Output this help text and exit"
   echo "  -n, --no-compile         Skip compilation of scripts on startup"
+  echo "      --dev                Start Zulu in Development Mode"
 }
 
 function _zulu_init_setup_completion() {
@@ -583,11 +584,18 @@ function _zulu_init() {
   zparseopts -D \
     h=help -help=help \
     c=check_for_update -check-for-update=check_for_update \
-    n=no_compile -no-compile=no_compile
+    n=no_compile -no-compile=no_compile \
+    -dev=dev
 
   if [[ -n $help ]]; then
     _zulu_init_usage
     return
+  fi
+
+  if [[ -n $dev ]]; then
+    export ZULU_DEV_MODE=1
+  else
+    export ZULU_DEV_MODE=0
   fi
 
   # Populate paths
@@ -625,4 +633,6 @@ function _zulu_init() {
   fi
 
   [[ -n $check_for_update ]] && _zulu_check_for_update
+
+  return
 }

--- a/src/zulu.zsh
+++ b/src/zulu.zsh
@@ -76,6 +76,11 @@ function _zulu_version() {
     return
   fi
 
+  # If we're in dev mode, re-source the command now
+  if (( $+functions[_zulu_${cmd}] )) && [[ $ZULU_DEV_MODE -eq 1 ]]; then
+    source "$base/core/src/commands/$cmd.zsh"
+  fi
+
   # Check if the requested command exists
   if (( ! $+functions[_zulu_${cmd}] )); then
     # If it doesn't, print usage information and exit


### PR DESCRIPTION
When selected, commands are re-sourced when they are called, to prevent the
need to rebuild Zulu and restart the terminal session between updates.

Fix #63 