### PR TITLE
Adds usage tracking within the app

### DIFF
--- a/src/commands/analytics.zsh
+++ b/src/commands/analytics.zsh
@@ -1,0 +1,87 @@
+###
+# Get a unique hash which refers to the user
+###
+function _zulu_analytics_user_key() {
+  local -a hash_cmds; hash_cmds=(sha256sum gsha256sum)
+  local cmd hash_cmd
+
+  # If a user ID is already set in the config file.
+  # we don't need to generate one
+  if zulu config user_id >/dev/null 2>&1; then
+    echo $(zulu config user_id)
+    return
+  fi
+
+  # Loop through each of the hashing commands
+  for hash_cmd in $hash_cmds; do
+    # Check if the command is installed
+    if builtin type $hash_cmd >/dev/null 2>&1; then
+      # It's installed, we'll set it to be used
+      # and break the loop
+      cmd=$hash_cmd
+      break
+    fi
+  done
+
+  # A hashing command could not be found, we'll just
+  # skip hashing for this user
+  if [[ -z $cmd ]]; then
+    return
+  fi
+
+  # Create a hash from the user's username and hostname
+  hash=$(echo -n "$USER@$HOST" | $cmd)
+
+  # Store the hash in the Zulu config file
+  # and return it
+  zulu config set user_id ${hash:0:$(( ${#hash} - 2 ))}
+}
+
+###
+# Send the event data to Heap
+###
+function _zulu_analytics_track() {
+  if ! _zulu_analytics_enabled; then
+    return
+  fi
+
+  local evt="$1" user="$(_zulu_analytics_user_key)"
+
+  # Yes, you could run this command to post data
+  # directly to our analytics provider, but please
+  # don't. We collect this data to allow us to see
+  # which of Zulu's features are most important to
+  # you, the user, and find ways to improve Zulu.
+  # If the data is inaccurate, it makes supporting
+  # Zulu more difficult. Please don't be a dick.
+  curl \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"app_id\": \"2918660738\",
+      \"identity\": \"$user\",
+      \"event\": \"$evt\"
+    }" 'https://heapanalytics.com/api/track' >/dev/null 2>&1
+}
+
+function _zulu_analytics_enabled() {
+  if ! zulu config analytics >/dev/null 2>&1; then
+    # Turn on by default
+    zulu config set analytics true >/dev/null 2>&1
+
+    # Let the user know they can opt-out
+    echo 'Zulu collects anonymous usage data to allow the developers to see
+which of Zulu'\''s features are most important to you, the user, and to
+continue to improve Zulu for you.
+
+If you'\''d like to opt-out of sending this anonymous data, you can do so by
+running the following command
+
+    zulu config set analytics false'
+  fi
+
+  # If the user has opted out, go no further
+  if [[ $(zulu config analytics) != 'true' ]]; then
+    return 1
+  fi
+}

--- a/src/zulu.zsh
+++ b/src/zulu.zsh
@@ -90,6 +90,12 @@ function zulu() {
     return 1
   fi
 
+
+  # If the user initiated this call, then track it
+  if [[ $ZULU_DEV_MODE -ne 1 && "${${(s/:/)funcfiletrace[1]}[1]}" != "$base/core/zulu" ]]; then
+    _zulu_analytics_track "Ran command: $cmd $2"
+  fi
+
   # Execute the requested command
   _zulu_${cmd} "${(@)@:2}"
 }

--- a/tests/_support/bootstrap
+++ b/tests/_support/bootstrap
@@ -49,6 +49,9 @@ if ! command git rev-parse --abbrev-ref @'{u}' &>/dev/null; then
   fi
 fi
 
+# Disable analytics whilst testing
+echo "analytics: false" >! "$ZULU_CONFIG_DIR/config.yml"
+
 # Ensure the progress indicator is hidden, so that we can
 # perform assertions against the output from commands
 export ZULU_NO_PROGRESS=1
@@ -58,5 +61,5 @@ export IFS=$oldIFS
 unset oldIFS
 
 # Source the embedded Zulu installation
-source "$PWD/zulu"
+source "$PWD/tests/_support/.zulu/core/zulu"
 zulu init

--- a/tests/commands/config.zunit
+++ b/tests/commands/config.zunit
@@ -1,25 +1,25 @@
 #!/usr/bin/env zunit
 
 @teardown {
-  cat /dev/null > tests/_support/.config/zulu/config.yml
+  echo "analytics: false" >! tests/_support/.config/zulu/config.yml
 }
 
 @test 'Test "zulu config list" returns contents of config.yml' {
-  echo "testing: true" > tests/_support/.config/zulu/config.yml
+  echo "testing: true" >> tests/_support/.config/zulu/config.yml
 
   run zulu config list
 
   assert $state equals 0
-  assert "$output" same_as "testing: true"
+  assert "$lines[${#lines}]" same_as "testing: true"
 }
 
 @test 'Test "zulu config" returns correct value' {
-  echo "testing: true" > tests/_support/.config/zulu/config.yml
+  echo "testing: true" >> tests/_support/.config/zulu/config.yml
 
   run zulu config testing
 
   assert $state equals 0
-  assert "$output" same_as "true"
+  assert "$lines[${#lines}]" same_as "true"
 }
 
 @test 'Test "zulu config set" sets value' {
@@ -31,7 +31,7 @@
   run zulu config list
 
   assert $state equals 0
-  assert "$output" same_as "rainbows: unicorns"
+  assert "$lines[${#lines}]" same_as "rainbows: unicorns"
 
   run zulu config rainbows
 
@@ -48,7 +48,7 @@
   run zulu config list
 
   assert $state equals 0
-  assert "$output" same_as "rainbows: unicorns"
+  assert "$lines[${#lines}]" same_as "rainbows: unicorns"
 
   run zulu config set rainbows pixies
 
@@ -58,7 +58,7 @@
   run zulu config list
 
   assert $state equals 0
-  assert "$output" same_as "rainbows: pixies"
+  assert "$lines[${#lines}]" same_as "rainbows: pixies"
 
   run zulu config rainbows
 


### PR DESCRIPTION
Data is collected anonymously, and only records the first two arguments
passed to Zulu. e.g. for `zulu var add TESTING 1` the data recorded
would be: `Ran command: var add`.

You can opt out by running `zulu config set analytics false`. The first time Zulu runs the analytics internally it will prompt the user with a message to tell them this.

Fix #67