### PR TITLE
Allow specifying package versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - curl -L https://raw.githubusercontent.com/molovo/revolver/master/revolver > .bin/revolver
   - curl -L https://raw.githubusercontent.com/molovo/color/master/color.zsh > .bin/color
   - curl -L https://raw.githubusercontent.com/molovo/zvm/master/zvm > .bin/zvm
-  - curl -L https://github.com/molovo/zunit/releases/download/v0.6.3/zunit > .bin/zunit
+  - curl -L https://github.com/molovo/zunit/releases/download/v0.7.0-alpha/zunit > .bin/zunit
   - chmod u+x .bin/{color,revolver,zunit,zvm}
   - export PATH="$HOME/.zvm/bin:$PWD/.bin:$PATH"
 before_script:

--- a/src/commands/info.zsh
+++ b/src/commands/info.zsh
@@ -7,6 +7,16 @@ function _zulu_info_usage() {
 }
 
 ###
+# Check if a package is installed
+###
+function _zulu_info_is_installed() {
+  local package="$1" base=${ZULU_DIR:-"${ZDOTDIR:-$HOME}/.zulu"}
+
+  [[ -d "$base/packages/$package" ]]
+  return $?
+}
+
+###
 # Extract package information from the index entry
 ###
 function _zulu_info_package() {
@@ -20,8 +30,7 @@ function _zulu_info_package() {
   author=$(jsonval $json 'author')
   packagetype=$(jsonval $json 'type')
 
-  installed=""
-  [[ -d "$base/packages/$package" ]] && installed="$(_zulu_color green '✔ Installed')"
+  _zulu_info_is_installed $name && installed="$(_zulu_color green '✔ Installed')"
 
   echo "$(_zulu_color white underline "$name") $installed"
   echo $description

--- a/src/commands/switch.zsh
+++ b/src/commands/switch.zsh
@@ -1,0 +1,87 @@
+###
+# Output usage information
+###
+function _zulu_switch_usage() {
+  echo $(_zulu_color yellow "Usage:")
+  echo "  zulu switch <options> <package>"
+  echo
+  echo $(_zulu_color yellow "Options:")
+  echo "  -b, --branch <branch>   Checkout the specified branch"
+  echo "  -t, --tag <tag>         Checkout the specified tag or commit"
+}
+
+###
+# Checkout the provided tag or branch in the package repository
+###
+function _zulu_switch_checkout() {
+  local package="$1" ref="$2"
+  local base=${ZULU_DIR:-"${ZDOTDIR:-$HOME}/.zulu"}
+
+  if ! _zulu_info_is_installed $package; then
+    echo $(_zulu_color red "Package $package is not installed")
+  fi
+
+  local oldPWD=$PWD
+  cd "$base/packages/$package"
+
+  git fetch origin >/dev/null 2>&1
+  output=$(git checkout -qf $ref 2>&1)
+  state=$?
+
+  cd $oldPWD
+  unset oldPWD
+
+  if [[ $state -ne 0 ]]; then
+    echo $(_zulu_color red "Failed to checkout $ref of package $package")
+    echo $output
+
+    return 1
+  fi
+
+  echo "$(_zulu_color green '✔') Successfully switched $package to $ref"
+}
+
+###
+# Zulu command to handle path manipulation
+###
+function _zulu_switch() {
+  local ctx base help branch tag ref
+
+  # Parse options
+  zparseopts -D h=help -help=help \
+    b:=branch -branch:=branch \
+    t:=tag -tag:=tag
+
+  # Output help and return if requested
+  if [[ -n $help ]]; then
+    _zulu_path_usage
+    return
+  fi
+
+  if [[ -z $branch && -z $tag ]]; then
+    echo $(_zulu_color red 'You must specify a branch or tag')
+    return 1
+  fi
+
+  if [[ -n $branch && -n $tag ]]; then
+    echo $(_zulu_color red 'You must only specify one of branch or tag')
+    return 1
+  fi
+
+  if [[ -n $branch ]]; then
+    shift branch
+    ref=$branch
+  fi
+
+  if [[ -n $tag ]]; then
+    shift tag
+    ref=$tag
+  fi
+
+  # Set up some variables
+  base=${ZULU_DIR:-"${ZDOTDIR:-$HOME}/.zulu"}
+  package="$1"
+
+  # Call the relevant function
+  _zulu_switch_checkout $package $ref
+}

--- a/src/zulu.zsh
+++ b/src/zulu.zsh
@@ -24,6 +24,7 @@ function _zulu_usage() {
   echo "  theme <theme>         Select a prompt theme"
   echo "  search                Search the package index"
   echo "  self-update           Update zulu"
+  echo "  switch                Switch to a different version of a package"
   echo "  sync                  Sync your Zulu environment to a remote repository"
   echo "  uninstall <package>   Uninstall a package"
   echo "  unlink <package>      Remove symlinks for a package"

--- a/tests/_support/bootstrap
+++ b/tests/_support/bootstrap
@@ -62,4 +62,4 @@ unset oldIFS
 
 # Source the embedded Zulu installation
 source "$PWD/tests/_support/.zulu/core/zulu"
-zulu init
+zulu init --dev

--- a/tests/commands/install.zunit
+++ b/tests/commands/install.zunit
@@ -28,3 +28,20 @@
   assert $state equals 1
   assert "${lines[1]}" same_as "\033[0;31mPlease specify a package name\033[0;m"
 }
+
+@test 'Test "zulu install --branch" checks out correct branch' {
+  run zulu install --no-autoselect-themes --ignore-dependencies --branch next zunit
+
+  assert $state equals 0
+  assert "${lines[${#lines}]%"${lines[${#lines}]##*[![:space:]]}"}" same_as "\033[0;32m✔\033[0;m Finished linking zunit"
+
+  local oldPWD=$PWD
+  cd "${ZULU_DIR:-"${ZDOTDIR:-$HOME}/.zulu"}/packages/zunit"
+
+  local branch=$(git status --short --branch -uno --ignore-submodules=all | head -1 | awk '{print $2}' 2>/dev/null)
+
+  assert "${branch%...*}" same_as 'next'
+
+  cd $oldPWD
+  unset oldPWD
+}

--- a/tests/commands/switch.zunit
+++ b/tests/commands/switch.zunit
@@ -1,0 +1,15 @@
+#!/usr/bin/env zunit
+
+@test 'Test "zulu switch --tag" checks out correct tag' {
+  run zulu switch --tag v0.6.1 zunit
+
+  assert $state equals 0
+  assert "${lines[${#lines}]%"${lines[${#lines}]##*[![:space:]]}"}" same_as "\033[0;32m✔\033[0;m Successfully switched zunit to v0.6.1"
+}
+
+@test 'Test "zulu switch --branch" checks out correct branch' {
+  run zulu switch --branch master zunit
+
+  assert $state equals 0
+  assert "${lines[${#lines}]%"${lines[${#lines}]##*[![:space:]]}"}" same_as "\033[0;32m✔\033[0;m Successfully switched zunit to master"
+}

--- a/tests/commands/uninstall.zunit
+++ b/tests/commands/uninstall.zunit
@@ -1,6 +1,10 @@
 #!/usr/bin/env zunit
 
 @test 'Test "zulu uninstall" uninstalls package' {
+  if [[ ! -d $PWD/tests/_support/.zulu/packages/crash ]]; then
+    skip 'Crash package not installed. Perhaps an earlier test failed?'
+  fi
+
   run zulu uninstall crash
 
   assert $state equals 0

--- a/zulu.zsh-completion
+++ b/zulu.zsh-completion
@@ -235,7 +235,9 @@ _zulu() {
           _arguments -A \
             '(-h --help)'{-h,--help}'[show help text and exit]' \
             '--ignore-dependencies[Don'\''t automatically install dependencies]' \
-            '--no-autoselect-themes[Don'\''t autoselect themes after installing]'
+            '--no-autoselect-themes[Don'\''t autoselect themes after installing]' \
+            '(-b --branch)'{-b,--branch}'[specify a branch to install]' \
+            '(-t --tag)'{-t,--tag}'[specify a tag or commit to install]'
 
           _arguments \
             '*: :_zulu_not_installed_packages'

--- a/zulu.zsh-completion
+++ b/zulu.zsh-completion
@@ -26,6 +26,7 @@ _zulu_commands=(
   'fpath:Functions for adding/removing directories from \$fpath'
   'config:Functions for getting/setting configuration values'
   'sync:Sync zulu environment to a remote repository'
+  'switch:Checkout a different version of a package'
 )
 
 ###
@@ -238,6 +239,14 @@ _zulu() {
 
           _arguments \
             '*: :_zulu_not_installed_packages'
+          ;;
+        (switch)
+          _arguments -A \
+            '(-b --branch)'{-b,--branch}'[specify a branch to install]' \
+            '(-t --tag)'{-t,--tag}'[specify a tag or commit to install]'
+
+          _arguments \
+            '*: :_zulu_installed_packages'
           ;;
         (info)
           _arguments \


### PR DESCRIPTION
* Adds a new `zulu switch` command which can be used to checkout a specific branch or tag (using `--branch` and `--tag` options).
* Also allows specifying version when installing packages by passing `--branch` or `--tag` to `zulu install`

Fix #72