### PR TITLE
Ensure `zulu bundle` installs the correct branch/tag

### DIFF
--- a/src/commands/bundle.zsh
+++ b/src/commands/bundle.zsh
@@ -42,7 +42,7 @@ function _zulu_bundle_dump() {
 # Uninstall packages not in packagefile
 ###
 function _zulu_bundle_cleanup() {
-  local -a installed; installed=($(zulu list --installed --simple))
+  local -a installed; installed=($(zulu list --installed --simple --branch --tag))
 
   # Loop through each of the installed packages
   for package in "${installed[@]}"; do

--- a/src/commands/bundle.zsh
+++ b/src/commands/bundle.zsh
@@ -42,7 +42,7 @@ function _zulu_bundle_dump() {
 # Uninstall packages not in packagefile
 ###
 function _zulu_bundle_cleanup() {
-  local -a installed; installed=($(zulu list --installed --short))
+  local -a installed; installed=($(zulu list --installed --simple))
 
   # Loop through each of the installed packages
   for package in "${installed[@]}"; do
@@ -107,15 +107,47 @@ function _zulu_bundle() {
     return $?
   fi
 
+  local oldIFS=$IFS
+  IFS=$'\n'
+
   # Load the list of packages
   packages=($(cat $packagefile))
 
+  IFS=$oldIFS
+  unset oldIFS
+
   # Loop through the packages
   for package in "${packages[@]}"; do
-    # Check if the package is installed already
-    if [[ ! -d "$base/packages/$package" ]]; then
-      # Install the package
-      zulu install $package
+    local package_name='' flag='' argument='' install_flags=''
+
+    # Separate the package name from any meta information
+    local -a parts meta
+    parts=(${(ps/, /)package})
+    package_name="${parts[1]}"
+    meta=(${(ps/: /)parts[2]})
+
+    # Skip the package if it is already installed
+    if _zulu_info_is_installed $package_name; then
+      continue
     fi
+
+    # Separate the meta information into flags and arguments
+    if [[ ${#meta} -gt 0 ]]; then
+      flag="${meta[1]}"
+      argument="${meta[2]}"
+
+      # Create the correct install flags
+      case ${flag} in
+        branch )
+          install_flags="--branch $argument"
+          ;;
+        tag )
+          install_flags="--tag $argument"
+          ;;
+      esac
+    fi
+
+    # Install the package
+    zulu install ${(ps/ /)install_flags} $package_name
   done
 }

--- a/src/commands/bundle.zsh
+++ b/src/commands/bundle.zsh
@@ -17,7 +17,7 @@ function _zulu_bundle_usage() {
 # Dump installed packages to file
 ###
 function _zulu_bundle_dump() {
-  local installed=$(zulu list --installed --short)
+  local installed=$(zulu list --installed --simple --branch --tag)
 
   # Check if the packagefile exists
   if [[ -f $packagefile ]]; then

--- a/src/commands/install.zsh
+++ b/src/commands/install.zsh
@@ -52,12 +52,6 @@ function _zulu_install_package() {
     return 1
   fi
 
-  packagefile="$config/packages"
-  in_packagefile=$(cat $packagefile | grep -e '^'${package}'$')
-  if [[ "$in_packagefile" = "" ]]; then
-    echo "$package" >> $packagefile
-  fi
-
   return
 }
 
@@ -176,4 +170,7 @@ function _zulu_install() {
       echo "$out"
     fi
   done
+
+  # Write the new packagefile contents
+  zulu bundle --dump --force
 }

--- a/src/commands/uninstall.zsh
+++ b/src/commands/uninstall.zsh
@@ -10,9 +10,17 @@ function _zulu_uninstall_usage() {
 # Install a package
 ###
 function _zulu_uninstall_package() {
-  local package json repo dir file link
+  local package root
 
   package="$1"
+
+  # Double check that the package name has been passed
+  if [[ -z $package ]]; then
+    echo $(_zulu_color red "Please specify a package name")
+    echo
+    _zulu_uninstall_usage
+    return 1
+  fi
 
   # Check if the package is already uninstalled
   root="$base/packages/$package"
@@ -24,10 +32,7 @@ function _zulu_uninstall_package() {
   #       get populated for some reason
   rm -rf "$root"
 
-  packagefile="$config/packages"
-  echo "$(cat $packagefile | grep -v -e "^${package}$")" >! $packagefile
-
-  return
+  return $?
 }
 
 ###
@@ -88,4 +93,6 @@ function _zulu_uninstall() {
       echo "$out"
     fi
   done
+
+  zulu bundle --dump --force
 }


### PR DESCRIPTION
Included in this PR:

- [x] Simplify the `zulu list` command internally (e7b1f37)
- [x] Add `--branch` and `--tag` options to `zulu list` (c0378ef)
- [x] Improve performance of `zulu list` (#84)
- [x] Print branch and tag information alongside package in packagefile
  Example output:
  ```
  agnoster
  autosuggestions, branch: develop
  filthy
  zunit, tag: v0.7.0
  ```
- [x] Ensure alphabetical order of packagefile is maintained when installing packages (0ba9cbc)
- [x] Parse branch and tag names in packagefile, and use those when installing with `zulu bundle` (5725551)

Fixes #78