### PR TITLE
Remove 5.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ addons:
       - autoconf
       - yodl
       - man
+language: generic
 cache:
   apt: true
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ cache:
 dist: trusty
 matrix:
   include:
-    - env: ZVM_VERSION='5.0.8'
     - env: ZVM_VERSION='5.1.1'
     - env: ZVM_VERSION='5.2'
     - env: ZVM_VERSION='5.3.1'

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Thanks for using Zulu. Zulu is a environment manager for ZSH, which aims to make
 
 ## Requirements
 
-* ZSH `5.0.2` or above
+* ZSH `5.1.1` or above
 * git `1.9.1` or above
 
 ## Installation

--- a/src/commands/install.zsh
+++ b/src/commands/install.zsh
@@ -122,6 +122,8 @@ function _zulu_install() {
     fi
   done
 
+  local error=0
+
   # Do a second loop, to do the actual install
   for package in "$packages[@]"; do
     # Get the JSON from the index
@@ -182,9 +184,14 @@ function _zulu_install() {
     else
       echo "$(_zulu_color red '✘') Error installing $package        "
       echo "$out"
+      error=1
     fi
   done
 
   # Write the new packagefile contents
   zulu bundle --dump --force
+
+  if [[ $error -ne 0 ]]; then
+    return 1
+  fi
 }

--- a/tests/_support/bootstrap
+++ b/tests/_support/bootstrap
@@ -63,9 +63,3 @@ unset oldIFS
 # Source the embedded Zulu installation
 source "$PWD/tests/_support/.zulu/core/zulu"
 zulu init --dev
-
-if [[ ! -d "$ZULU_DIR/packages/filthy" ]]; then
-  # The filthy theme used to be a default, and so is used in multiple tests
-  # We need to make sure it is installed
-  zulu install filthy
-fi

--- a/tests/commands/bundle.zunit
+++ b/tests/commands/bundle.zunit
@@ -1,16 +1,22 @@
 #!/usr/bin/env zunit
 
+@setup {
+  if [[ -d "$PWD/tests/_support/.zulu/packages/dummy" ]]; then
+    zulu uninstall dummy
+  fi
+}
+
 @teardown {
-  zulu uninstall async
+  zulu uninstall dummy
 }
 
 @test 'Test "zulu bundle" installs package' {
   # Add an extra package to the packagefile
-  echo 'async' >> "$PWD/tests/_support/.config/zulu/packages"
+  echo 'dummy' >> "$PWD/tests/_support/.config/zulu/packages"
 
   run zulu bundle
 
   assert $state equals 0
-  assert "${lines[${#lines}]%"${lines[${#lines}]##*[![:space:]]}"}" same_as "\033[0;32m✔\033[0;m Finished linking async"
-  assert "$PWD/tests/_support/.zulu/packages/async" is_dir
+  assert "${lines[${#lines}]%"${lines[${#lines}]##*[![:space:]]}"}" same_as "\033[0;32m✔\033[0;m Finished linking dummy"
+  assert "$PWD/tests/_support/.zulu/packages/dummy" is_dir
 }

--- a/tests/commands/bundle.zunit
+++ b/tests/commands/bundle.zunit
@@ -1,13 +1,15 @@
 #!/usr/bin/env zunit
 
 @setup {
-  if [[ -d "$PWD/tests/_support/.zulu/packages/dummy" ]]; then
+  if _zulu_info_is_installed dummy; then
     zulu uninstall dummy
   fi
 }
 
 @teardown {
-  zulu uninstall dummy
+  if _zulu_info_is_installed dummy; then
+    zulu uninstall dummy
+  fi
 }
 
 @test 'Test "zulu bundle" installs package' {

--- a/tests/commands/install.zunit
+++ b/tests/commands/install.zunit
@@ -1,13 +1,13 @@
 #!/usr/bin/env zunit
 
 @setup {
-  if [[ -d "$PWD/tests/_support/.zulu/packages/dummy" ]]; then
+  if _zulu_info_is_installed dummy; then
     zulu uninstall dummy
   fi
 }
 
 @teardown {
-  if [[ -d "$PWD/tests/_support/.zulu/packages/dummy" ]]; then
+  if _zulu_info_is_installed dummy; then
     zulu uninstall dummy
   fi
 }

--- a/tests/commands/install.zunit
+++ b/tests/commands/install.zunit
@@ -1,18 +1,42 @@
 #!/usr/bin/env zunit
 
-@test 'Test "zulu install" installs package' {
-  run zulu install --no-autoselect-themes --ignore-dependencies crash
+@setup {
+  if [[ -d "$PWD/tests/_support/.zulu/packages/dummy" ]]; then
+    zulu uninstall dummy
+  fi
+}
 
+@teardown {
+  if [[ -d "$PWD/tests/_support/.zulu/packages/dummy" ]]; then
+    zulu uninstall dummy
+  fi
+}
+
+@test 'Test "zulu install" installs package' {
+  # Install the dummy package
+  run zulu install --no-autoselect-themes --ignore-dependencies dummy
+
+  # Assert that the package installed successfully
   assert $state equals 0
-  assert "${lines[${#lines}]%"${lines[${#lines}]##*[![:space:]]}"}" same_as "\033[0;32m✔\033[0;m Finished linking crash"
-  assert "$PWD/tests/_support/.zulu/packages/crash" is_dir
+  assert "${lines[${#lines}]%"${lines[${#lines}]##*[![:space:]]}"}" same_as "\033[0;32m✔\033[0;m Finished linking dummy"
+  assert "$PWD/tests/_support/.zulu/packages/dummy" is_dir
 }
 
 @test 'Test "zulu install" fails for installed package' {
-  run zulu install --no-autoselect-themes --ignore-dependencies crash
+  # Install the dummy package
+  run zulu install --no-autoselect-themes --ignore-dependencies dummy
 
+  # Assert that the package installed successfully
   assert $state equals 0
-  assert "${lines[${#lines}]%"${lines[${#lines}]##*[![:space:]]}"}" same_as "\033[0;31mPackage 'crash' is already installed\033[0;m"
+  assert "${lines[${#lines}]%"${lines[${#lines}]##*[![:space:]]}"}" same_as "\033[0;32m✔\033[0;m Finished linking dummy"
+  assert "$PWD/tests/_support/.zulu/packages/dummy" is_dir
+
+  # Install the package again and record the output
+  run zulu install --no-autoselect-themes --ignore-dependencies dummy
+
+  # Assert that the package failed to install
+  assert $state equals 1
+  assert "${lines[${#lines}]%"${lines[${#lines}]##*[![:space:]]}"}" same_as "\033[0;31mPackage 'dummy' is already installed\033[0;m"
 }
 
 @test 'Test "zulu install" fails for non-existent package' {
@@ -30,17 +54,20 @@
 }
 
 @test 'Test "zulu install --branch" checks out correct branch' {
-  run zulu install --no-autoselect-themes --ignore-dependencies --branch next zunit
+  # Install the 'testing' branch of the dummy package
+  run zulu install --no-autoselect-themes --ignore-dependencies --branch testing dummy
 
+  # Assert that the package installed successfully
   assert $state equals 0
-  assert "${lines[${#lines}]%"${lines[${#lines}]##*[![:space:]]}"}" same_as "\033[0;32m✔\033[0;m Finished linking zunit"
+  assert "${lines[${#lines}]%"${lines[${#lines}]##*[![:space:]]}"}" same_as "\033[0;32m✔\033[0;m Finished linking dummy"
 
+  # Change to the package directory and check the checked out branch
   local oldPWD=$PWD
-  cd "${ZULU_DIR:-"${ZDOTDIR:-$HOME}/.zulu"}/packages/zunit"
+  cd "${ZULU_DIR:-"${ZDOTDIR:-$HOME}/.zulu"}/packages/dummy"
 
   local branch=$(git status --short --branch -uno --ignore-submodules=all | head -1 | awk '{print $2}' 2>/dev/null)
 
-  assert "${branch%...*}" same_as 'next'
+  assert "${branch%...*}" same_as 'testing'
 
   cd $oldPWD
   unset oldPWD

--- a/tests/commands/install.zunit
+++ b/tests/commands/install.zunit
@@ -36,7 +36,7 @@
 
   # Assert that the package failed to install
   assert $state equals 1
-  assert "${lines[${#lines}]%"${lines[${#lines}]##*[![:space:]]}"}" same_as "\033[0;31mPackage 'dummy' is already installed\033[0;m"
+  assert "${lines[${#lines}]%"${lines[${#lines}]##*[![:space:]]}"}" same_as "\033[0;31m✘\033[0;m Error installing dummy"
 }
 
 @test 'Test "zulu install" fails for non-existent package' {

--- a/tests/commands/self-update.zunit
+++ b/tests/commands/self-update.zunit
@@ -12,8 +12,8 @@
 
   # Stash any uncommitted changes and rewind one commit to ensure
   # updates are available
-  git stash >/dev/null 2>&1
-  git reset --hard HEAD~1 >/dev/null 2>&1
+  git stash 2>&1
+  git reset --hard HEAD~1 2>&1
 
   cd $oldPWD
   unset oldPWD
@@ -57,8 +57,8 @@
 
   # Stash any uncommitted changes and rewind one commit to ensure
   # updates are available
-  git stash >/dev/null 2>&1
-  git reset --hard HEAD~1 >/dev/null 2>&1
+  git stash 2>&1
+  git reset --hard HEAD~1 2>&1
 
   # Add a test line to the end of a source file
   echo 'thisisatest' >> README.md

--- a/tests/commands/switch.zunit
+++ b/tests/commands/switch.zunit
@@ -1,15 +1,27 @@
 #!/usr/bin/env zunit
 
+@setup {
+  if ! _zulu_info_is_installed dummy; then
+    zulu install dummy
+  fi
+}
+
+@teardown {
+  if _zulu_info_is_installed dummy; then
+    zulu uninstall dummy
+  fi
+}
+
 @test 'Test "zulu switch --tag" checks out correct tag' {
-  run zulu switch --tag v0.6.1 zunit
+  run zulu switch --tag v1.0.0 dummy
 
   assert $state equals 0
-  assert "${lines[${#lines}]%"${lines[${#lines}]##*[![:space:]]}"}" same_as "\033[0;32m✔\033[0;m Successfully switched zunit to v0.6.1"
+  assert "${lines[${#lines}]%"${lines[${#lines}]##*[![:space:]]}"}" same_as "\033[0;32m✔\033[0;m Successfully switched dummy to v1.0.0"
 }
 
 @test 'Test "zulu switch --branch" checks out correct branch' {
-  run zulu switch --branch master zunit
+  run zulu switch --branch testing dummy
 
   assert $state equals 0
-  assert "${lines[${#lines}]%"${lines[${#lines}]##*[![:space:]]}"}" same_as "\033[0;32m✔\033[0;m Successfully switched zunit to master"
+  assert "${lines[${#lines}]%"${lines[${#lines}]##*[![:space:]]}"}" same_as "\033[0;32m✔\033[0;m Successfully switched dummy to testing"
 }

--- a/tests/commands/uninstall.zunit
+++ b/tests/commands/uninstall.zunit
@@ -1,21 +1,36 @@
 #!/usr/bin/env zunit
 
-@test 'Test "zulu uninstall" uninstalls package' {
-  if [[ ! -d $PWD/tests/_support/.zulu/packages/crash ]]; then
-    skip 'Crash package not installed. Perhaps an earlier test failed?'
+@setup {
+  if ! _zulu_info_is_installed dummy; then
+    zulu install --no-autoselect-themes --ignore-dependencies dummy
   fi
+}
 
-  run zulu uninstall crash
+@teardown {
+  if _zulu_info_is_installed dummy; then
+    zulu uninstall dummy
+  fi
+}
+
+@test 'Test "zulu uninstall" uninstalls package' {
+  run zulu uninstall dummy
 
   assert $state equals 0
-  assert "${lines[${#lines}]%"${lines[${#lines}]##*[![:space:]]}"}" same_as "\033[0;32m✔\033[0;m Finished uninstalling crash"
+  assert "${lines[${#lines}]%"${lines[${#lines}]##*[![:space:]]}"}" same_as "\033[0;32m✔\033[0;m Finished uninstalling dummy"
 }
 
 @test 'Test "zulu uninstall" fails for not-installed package' {
-  run zulu uninstall crash
+  # Uninstall the package once
+  run zulu uninstall dummy
+
+  assert $state equals 0
+  assert "${lines[${#lines}]%"${lines[${#lines}]##*[![:space:]]}"}" same_as "\033[0;32m✔\033[0;m Finished uninstalling dummy"
+
+  # Run the uninstall again, this time it should fail
+  run zulu uninstall dummy
 
   assert $state equals 1
-  assert "${lines[${#lines}]%"${lines[${#lines}]##*[![:space:]]}"}" same_as "\033[0;31mPackage 'crash' is not installed\033[0;m"
+  assert "${lines[${#lines}]%"${lines[${#lines}]##*[![:space:]]}"}" same_as "\033[0;31mPackage 'dummy' is not installed\033[0;m"
 }
 
 @test 'Test "zulu uninstall" fails for non-existent package' {

--- a/tests/commands/upgrade.zunit
+++ b/tests/commands/upgrade.zunit
@@ -1,8 +1,20 @@
 #!/usr/bin/env zunit
 
+@setup {
+  if ! _zulu_info_is_installed dummy; then
+    zulu install dummy
+  fi
+}
+
+@teardown {
+  if _zulu_info_is_installed dummy; then
+    zulu uninstall dummy
+  fi
+}
+
 @test 'Test "zulu upgrade --check" finds package updates' {
   oldPWD=$PWD
-  cd tests/_support/.zulu/packages/filthy
+  cd tests/_support/.zulu/packages/dummy
 
   if ! command git rev-parse --abbrev-ref @'{u}' &>/dev/null; then
     cd $oldPWD
@@ -33,7 +45,7 @@
 
 @test 'Test "zulu upgrade" updates package repository' {
   oldPWD=$PWD
-  cd tests/_support/.zulu/packages/filthy
+  cd tests/_support/.zulu/packages/dummy
 
   if ! command git rev-parse --abbrev-ref @'{u}' &>/dev/null; then
     cd $oldPWD
@@ -47,12 +59,12 @@
   run zulu upgrade -y
 
   assert $state equals 0
-  assert "${lines[${#lines}]%"${lines[${#lines}]##*[![:space:]]}"}" same_as "\033[0;32m✔\033[0;m Finished linking filthy"
+  assert "${lines[${#lines}]%"${lines[${#lines}]##*[![:space:]]}"}" same_as "\033[0;32m✔\033[0;m Finished linking dummy"
 }
 
 @test 'Test "zulu upgrade" preserves local changes in package repository' {
   oldPWD=$PWD
-  cd tests/_support/.zulu/packages/filthy
+  cd tests/_support/.zulu/packages/dummy
 
   if ! command git rev-parse --abbrev-ref @'{u}' &>/dev/null; then
     cd $oldPWD
@@ -73,7 +85,7 @@
 
   # Assert the update was successful
   assert $state equals 0
-  assert "${lines[${#lines}]%"${lines[${#lines}]##*[![:space:]]}"}" same_as "\033[0;32m✔\033[0;m Finished linking filthy"
+  assert "${lines[${#lines}]%"${lines[${#lines}]##*[![:space:]]}"}" same_as "\033[0;32m✔\033[0;m Finished linking dummy"
 
   # Assert the additional line still exists in the file
   assert "$(tail -1 README.md)" same_as 'thisisatest'

--- a/tests/commands/upgrade.zunit
+++ b/tests/commands/upgrade.zunit
@@ -49,6 +49,12 @@
     skip 'Cannot test upgrade without an upstream'
   fi
 
+  # Stash any uncommitted changes and
+  git stash 2>&1
+
+  # Rewind one commit to ensure updates are available
+  git reset --hard HEAD~1 2>&1
+
   cd $oldPWD
   unset oldPWD
 

--- a/tests/commands/upgrade.zunit
+++ b/tests/commands/upgrade.zunit
@@ -23,14 +23,14 @@
   fi
 
   # Stash any uncommitted changes and
-  git stash >/dev/null 2>&1
+  git stash 2>&1
 
   # Fetch commits from the remote, since the existing clone is a
   # shallow one
-  git fetch --unshallow >/dev/null 2>&1
+  git fetch --unshallow 2>&1
 
   # Rewind one commit to ensure updates are available
-  git reset --hard HEAD~1 >/dev/null 2>&1
+  git reset --hard HEAD~1 2>&1
 
   cd $oldPWD
   unset oldPWD
@@ -74,8 +74,8 @@
 
   # Stash any uncommitted changes and rewind one commit to ensure
   # updates are available
-  git stash >/dev/null 2>&1
-  git reset --hard HEAD~1 >/dev/null 2>&1
+  git stash 2>&1
+  git reset --hard HEAD~1 2>&1
 
   # Add a test line to the end of a source file
   echo 'thisisatest' >> README.md

--- a/tests/commands/upgrade.zunit
+++ b/tests/commands/upgrade.zunit
@@ -25,10 +25,6 @@
   # Stash any uncommitted changes and
   git stash 2>&1
 
-  # Fetch commits from the remote, since the existing clone is a
-  # shallow one
-  git fetch --unshallow 2>&1
-
   # Rewind one commit to ensure updates are available
   git reset --hard HEAD~1 2>&1
 


### PR DESCRIPTION
This branch is a proposal which removes support for ZSH `5.0.2` through `5.0.8`. As Zulu has grown these versions have become harder to support, and currently fail a lot of the test suite.

This PR is currently a single commit ahead of the `next` branch, and removes ZSH `5.0.8` from the versions tested, effectively dropping it from support. Please vote with a thumbs up or down, whether you would like to see this merged.

If voting passes, the following additional changes will be made:

- [ ] Remove version checks which are no longer required
  - [ ] https://github.com/zulu-zsh/zulu/blob/master/src/commands/upgrade.zsh#L83
  - [ ] https://github.com/zulu-zsh/zulu/blob/master/src/commands/init.zsh#L533