### PR TITLE
Enforce builtins and important system commands

### DIFF
--- a/src/commands/alias.zsh
+++ b/src/commands/alias.zsh
@@ -15,7 +15,7 @@ function _zulu_alias_usage() {
 # Add an alias
 ###
 function _zulu_alias_add() {
-  locwal existing alias cmd
+  local existing alias cmd
 
   alias="$1"
   cmd="${(@)@:2}"

--- a/src/commands/alias.zsh
+++ b/src/commands/alias.zsh
@@ -2,34 +2,34 @@
 # Output usage information
 ###
 function _zulu_alias_usage() {
-  echo $(_zulu_color yellow "Usage:")
-  echo "  zulu alias <context> [args]"
-  echo
-  echo $(_zulu_color yellow "Contexts:")
-  echo "  add <alias> <command>   Add an alias"
-  echo "  load                    Load all aliases from alias file"
-  echo "  rm <alias>              Remove an alias"
+  builtin echo $(_zulu_color yellow "Usage:")
+  builtin echo "  zulu alias <context> [args]"
+  builtin echo
+  builtin echo $(_zulu_color yellow "Contexts:")
+  builtin echo "  add <alias> <command>   Add an alias"
+  builtin echo "  load                    Load all aliases from alias file"
+  builtin echo "  rm <alias>              Remove an alias"
 }
 
 ###
 # Add an alias
 ###
 function _zulu_alias_add() {
-  local existing alias cmd
+  locwal existing alias cmd
 
   alias="$1"
   cmd="${(@)@:2}"
 
-  existing=$(cat $aliasfile | grep "alias $alias=")
+  existing=$(command cat $aliasfile | command grep "alias $alias=")
   if [[ $existing != "" ]]; then
-    echo $(_zulu_color red "Alias '$alias' already exists")
+    builtin echo $(_zulu_color red "Alias '$alias' already exists")
     return 1
   fi
 
-  echo "alias $alias='$cmd'" >> $aliasfile
+  builtin echo "alias $alias='$cmd'" >> $aliasfile
 
   zulu alias load
-  echo "$(_zulu_color green '✔') Alias '$alias' added"
+  builtin echo "$(_zulu_color green '✔') Alias '$alias' added"
 }
 
 ###
@@ -40,24 +40,24 @@ function _zulu_alias_rm() {
 
   alias="$1"
 
-  existing=$(cat $aliasfile | grep "alias $alias=")
+  existing=$(command cat $aliasfile | command grep "alias $alias=")
   if [[ $existing = "" ]]; then
-    echo $(_zulu_color red "Alias '$alias' does not exist")
+    builtin echo $(_zulu_color red "Alias '$alias' does not exist")
     return 1
   fi
 
-  echo "$(cat $aliasfile | grep -v "alias $alias=")" >! $aliasfile
+  builtin echo "$(command cat $aliasfile | command grep -v "alias $alias=")" >! $aliasfile
   unalias $alias
 
   zulu alias load
-  echo "$(_zulu_color green '✔') Alias '$alias' removed"
+  builtin echo "$(_zulu_color green '✔') Alias '$alias' removed"
 }
 
 ###
 # Load aliases
 ###
 function _zulu_alias_load() {
-  source $aliasfile
+  builtin source $aliasfile
 }
 
 ###
@@ -67,7 +67,7 @@ function _zulu_alias() {
   local ctx base aliasfile
 
   # Parse options
-  zparseopts -D h=help -help=help
+  builtin zparseopts -D h=help -help=help
 
   # Output help and return if requested
   if [[ -n $help ]]; then

--- a/src/commands/analytics.zsh
+++ b/src/commands/analytics.zsh
@@ -8,7 +8,7 @@ function _zulu_analytics_user_key() {
   # If a user ID is already set in the config file.
   # we don't need to generate one
   if zulu config user_id >/dev/null 2>&1; then
-    echo $(zulu config user_id)
+    builtin echo $(zulu config user_id)
     return
   fi
 
@@ -30,7 +30,7 @@ function _zulu_analytics_user_key() {
   fi
 
   # Create a hash from the user's username and hostname
-  hash=$(echo -n "$USER@$HOST" | $cmd)
+  hash=$(builtin echo -n "$USER@$HOST" | $cmd)
 
   # Store the hash in the Zulu config file
   # and return it
@@ -54,7 +54,7 @@ function _zulu_analytics_track() {
   # you, the user, and find ways to improve Zulu.
   # If the data is inaccurate, it makes supporting
   # Zulu more difficult. Please don't be a dick.
-  curl \
+  command curl \
     -X POST \
     -H "Content-Type: application/json" \
     -d "{
@@ -70,7 +70,7 @@ function _zulu_analytics_enabled() {
     zulu config set analytics true >/dev/null 2>&1
 
     # Let the user know they can opt-out
-    echo 'Zulu collects anonymous usage data to allow the developers to see
+    builtin echo 'Zulu collects anonymous usage data to allow the developers to see
 which of Zulu'\''s features are most important to you, the user, and to
 continue to improve Zulu for you.
 

--- a/src/commands/bundle.zsh
+++ b/src/commands/bundle.zsh
@@ -2,15 +2,15 @@
 # Print usage information
 ###
 function _zulu_bundle_usage() {
-  echo $(_zulu_color yellow "Usage:")
-  echo "  zulu bundle [options]"
-  echo
-  echo $(_zulu_color yellow "Options:")
-  echo "  -c, --cleanup        Uninstall packages not in packagefile"
-  echo "  -f, --file           Specify a packagefile"
-  echo "  -d, --dump           Dump installed packages to packagefile"
-  echo "  -h, --help           Output this help text and exit"
-  echo "  -x, --force          Force writing of packages to an existing file"
+  builtin echo $(_zulu_color yellow "Usage:")
+  builtin echo "  zulu bundle [options]"
+  builtin echo
+  builtin echo $(_zulu_color yellow "Options:")
+  builtin echo "  -c, --cleanup        Uninstall packages not in packagefile"
+  builtin echo "  -f, --file           Specify a packagefile"
+  builtin echo "  -d, --dump           Dump installed packages to packagefile"
+  builtin echo "  -h, --help           Output this help text and exit"
+  builtin echo "  -x, --force          Force writing of packages to an existing file"
 }
 
 ###
@@ -23,18 +23,18 @@ function _zulu_bundle_dump() {
   if [[ -f $packagefile ]]; then
     # If the --force option was passed, overwrite it
     if [[ -n $force ]]; then
-      echo ${(@F)installed} >! $packagefile
+      builtin echo ${(@F)installed} >! $packagefile
       return
     fi
 
     # Throw an error
-    echo $(_zulu_color red "Packagefile at $packagefile already exists")
-    echo 'Use `zulu bundle --dump --force` to overwrite'
+    builtin echo $(_zulu_color red "Packagefile at $packagefile already exists")
+    builtin echo 'Use `zulu bundle --dump --force` to overwrite'
     return 1
   fi
 
   # Write to the packagefile
-  echo ${(@F)installed} > $packagefile
+  builtin echo ${(@F)installed} > $packagefile
   return
 }
 
@@ -63,7 +63,7 @@ function _zulu_bundle() {
   local help file cleanup dump force base config packagefile packages
 
   # Parse options
-  zparseopts -D h=help -help=help \
+  builtin zparseopts -D h=help -help=help \
                 f:=file -file:=file \
                 c=cleanup -cleanup=cleanup \
                 d=dump -dump=dump \
@@ -84,7 +84,7 @@ function _zulu_bundle() {
 
   # If a file is passed, use that as the packagefile
   if [[ -n $file ]]; then
-    shift file
+    builtin shift file
     packagefile="$file"
   fi
 
@@ -97,7 +97,7 @@ function _zulu_bundle() {
   # Check that the packagefile exists, and throw an
   # error if it does not
   if [[ ! -f $packagefile ]]; then
-    echo $(_zulu_color red 'Packagefile cannot be found')
+    builtin echo $(_zulu_color red 'Packagefile cannot be found')
     return 1
   fi
 
@@ -114,7 +114,7 @@ function _zulu_bundle() {
   packages=($(cat $packagefile))
 
   IFS=$oldIFS
-  unset oldIFS
+  builtin unset oldIFS
 
   # Loop through the packages
   for package in "${packages[@]}"; do

--- a/src/commands/cdpath.zsh
+++ b/src/commands/cdpath.zsh
@@ -2,13 +2,13 @@
 # Output usage information
 ###
 function _zulu_cdpath_usage() {
-  echo $(_zulu_color yellow "Usage:")
-  echo "  zulu cdpath <context> <dir>"
-  echo
-  echo $(_zulu_color yellow "Context:")
-  echo "  add <dir>   Add a directory to \$cdpath"
-  echo "  reset       Replace the current session \$cdpath with the stored dirs"
-  echo "  rm <dir>    Remove a directory from \$cdpath"
+  builtin echo $(_zulu_color yellow "Usage:")
+  builtin echo "  zulu cdpath <context> <dir>"
+  builtin echo
+  builtin echo $(_zulu_color yellow "Context:")
+  builtin echo "  add <dir>   Add a directory to \$cdpath"
+  builtin echo "  reset       Replace the current session \$cdpath with the stored dirs"
+  builtin echo "  rm <dir>    Remove a directory from \$cdpath"
 }
 
 ###
@@ -21,13 +21,13 @@ function _zulu_cdpath_parse() {
   if [[ -d "$PWD/$dir" ]]; then
     # If the directory exists in the current working directory
     # convert the relative path to absolute
-    echo "$PWD/$dir"
+    builtin echo "$PWD/$dir"
   elif [[ -d "$dir" ]]; then
     # If the directory exists as an absolute path, we can use it directly
-    echo "$dir"
+    builtin echo "$dir"
   elif [[ "$check_existing" != "false" ]]; then
     # The directory could not be found
-    echo $dir
+    builtin echo $dir
     return 1
   fi
 }
@@ -49,9 +49,9 @@ function _zulu_cdpath_add() {
       # Add the directory to the array of items
       items+="$dir"
 
-      echo "$(_zulu_color green '✔') $dir added to \$cdpath"
+      builtin echo "$(_zulu_color green '✔') $dir added to \$cdpath"
     else
-      echo "$(_zulu_color red '✘') $dir cannot be found"
+      builtin echo "$(_zulu_color red '✘') $dir cannot be found"
     fi
 
   done
@@ -80,7 +80,7 @@ function _zulu_cdpath_rm() {
 
     # If parsing returned with an error, output the error and return
     if [[ ! $? -eq 0 ]]; then
-      echo $dir
+      builtin echo $dir
       return 1
     fi
 
@@ -92,7 +92,7 @@ function _zulu_cdpath_rm() {
       fi
     done
 
-    echo "$(_zulu_color green '✔') $dir removed from \$cdpath"
+    builtin echo "$(_zulu_color green '✔') $dir removed from \$cdpath"
   done
 
   # Store the new paths in the pathfile, and override $cdpath
@@ -110,9 +110,9 @@ function _zulu_cdpath_store() {
   separator=$'\n'
   local oldIFS=$IFS
   IFS="$separator"; out="${items[*]/#/${separator}}"
-  echo ${out:${#separator}} >! $pathfile
+  builtin echo ${out:${#separator}} >! $pathfile
   IFS=$oldIFS
-  unset oldIFS
+  builtin unset oldIFS
 }
 
 ###
@@ -135,7 +135,7 @@ function _zulu_cdpath() {
   local ctx base pathfile
 
   # Parse options
-  zparseopts -D h=help -help=help
+  builtin zparseopts -D h=help -help=help
 
   # Output help and return if requested
   if [[ -n $help ]]; then
@@ -150,7 +150,7 @@ function _zulu_cdpath() {
 
   # If no context is passed, output the contents of the pathfile
   if [[ "$1" = "" ]]; then
-    cat "$pathfile"
+    command cat "$pathfile"
     return
   fi
 

--- a/src/commands/compile.zsh
+++ b/src/commands/compile.zsh
@@ -4,8 +4,8 @@
 # Output usage information and exit
 ###
 function _zulu_compile_usage() {
-  echo '\033[0;32mUsage:\033[0;m'
-  echo '  zulu_compile [options]'
+  builtin echo '\033[0;32mUsage:\033[0;m'
+  builtin echo '  zulu_compile [options]'
 }
 
 ###
@@ -15,14 +15,14 @@ function _zulu_compile_usage() {
 function _zulu_compile_if_needed() {
   local file="$1" follow_symlinks
 
-  zparseopts -D \
+  builtin zparseopts -D \
     f=follow_symlinks -follow-symlinks=follow_symlinks
 
   # We can't compile files that do not exist
   [[ ! -e $file ]] && return
 
   # Resolve symlinks if necessary
-  [[ -n $follow_symlinks && -L $file ]] && file=$(readlink $file)
+  [[ -n $follow_symlinks && -L $file ]] && file=$(command readlink $file)
 
   # Check if the file is newer than it's compiled version,
   # and recompile if necessary
@@ -39,7 +39,7 @@ function _zulu_compile_if_needed() {
   local config=${ZULU_CONFIG_DIR:-"${ZDOTDIR:-$HOME}/.config/zulu"}
   local help version
 
-  zparseopts -D \
+  builtin zparseopts -D \
     h=help -help=help
 
   if [[ -n $help ]]; then

--- a/src/commands/config.zsh
+++ b/src/commands/config.zsh
@@ -2,13 +2,13 @@
 # Output usage information
 ###
 function _zulu_config_usage() {
-  echo $(_zulu_color yellow "Usage:")
-  echo "  zulu config <args...>"
-  echo
-  echo $(_zulu_color yellow "Contexts:")
-  echo "  list                List all config values"
-  echo "  get <key>           Get a config value"
-  echo "  set <key> <value>   Set a config value"
+  builtin echo $(_zulu_color yellow "Usage:")
+  builtin echo "  zulu config <args...>"
+  builtin echo
+  builtin echo $(_zulu_color yellow "Contexts:")
+  builtin echo "  list                List all config values"
+  builtin echo "  get <key>           Get a config value"
+  builtin echo "  set <key> <value>   Set a config value"
 }
 
 ###
@@ -21,13 +21,13 @@ function _zulu_config_set() {
 
   # Rewrite the config file, omitting the key
   # we're setting if it exists
-  echo "$(cat $configfile | grep -v -E "^$key:")" >! $configfile
+  builtin echo "$(command cat $configfile | command grep -v -E "^$key:")" >! $configfile
 
   # Write the new value to the config file
-  echo "$key: $value" >> $configfile
+  builtin echo "$key: $value" >> $configfile
 
   # Write the config file again, stripping out any blank lines
-  echo "$(cat $configfile | grep -v -E '^\s*$')" >! $configfile
+  builtin echo "$(command cat $configfile | command grep -v -E '^\s*$')" >! $configfile
 
   zulu config $key
 }
@@ -44,7 +44,7 @@ function _zulu_config_get() {
     return 1
   fi
 
-  echo "$zulu_config[$key]"
+  builtin echo "$zulu_config[$key]"
 }
 
 ###
@@ -52,7 +52,7 @@ function _zulu_config_get() {
 ###
 function _zulu_config_load {
   [[ ! -f $configfile ]] && touch $configfile
-  eval $(_zulu_config_parse_yaml)
+  builtin eval $(_zulu_config_parse_yaml)
 }
 
 ###
@@ -63,8 +63,8 @@ function _zulu_config_parse_yaml() {
   local s w fs prefix='zulu_config'
   s='[[:space:]]*'
   w='[a-zA-Z0-9_]*'
-  fs="$(echo @|tr @ '\034')"
-  sed -ne "s|^\(${s}\)\(${w}\)${s}:${s}\"\(.*\)\"${s}\$|\1${fs}\2${fs}\3|p" \
+  fs="$(builtin echo @|tr @ '\034')"
+  command sed -ne "s|^\(${s}\)\(${w}\)${s}:${s}\"\(.*\)\"${s}\$|\1${fs}\2${fs}\3|p" \
       -e "s|^\(${s}\)\(${w}\)${s}[:-]${s}\(.*\)${s}\$|\1${fs}\2${fs}\3|p" "$configfile" |
   awk -F"${fs}" '{
   indent = length($1)/2;
@@ -74,7 +74,7 @@ function _zulu_config_parse_yaml() {
           vn=""; for (i=0; i<indent; i++) {vn=(vn)(vname[i])("_")}
           printf("%s%s[%s]=\"%s\"\n", "'"$prefix"'",vn, $2, $3);
       }
-  }' | sed 's/_=/+=/g'
+  }' | command sed 's/_=/+=/g'
 }
 
 ###
@@ -84,7 +84,7 @@ function _zulu_config() {
   local ctx
   local configfile="${ZULU_CONFIG_DIR:-"${ZDOTDIR:-$HOME}/.config/zulu"}/config.yml"
 
-  zparseopts -D h=help -help=help
+  builtin zparseopts -D h=help -help=help
 
   # Output help and return if requested
   if [[ -n $help ]]; then
@@ -97,7 +97,7 @@ function _zulu_config() {
   ctx="$1"
   case $ctx in
     list )
-      cat $configfile
+      command cat $configfile
       ;;
     set )
       _zulu_config_set "${(@)@:2}"

--- a/src/commands/fpath.zsh
+++ b/src/commands/fpath.zsh
@@ -2,13 +2,13 @@
 # Output usage information
 ###
 function _zulu_fpath_usage() {
-  echo $(_zulu_color yellow "Usage:")
-  echo "  zulu fpath <context> <dir>"
-  echo
-  echo $(_zulu_color yellow "Context:")
-  echo "  add <dir>   Add a directory to \$fpath"
-  echo "  reset       Replace the current session \$fpath with the stored dirs"
-  echo "  rm <dir>    Remove a directory from \$fpath"
+  builtin echo $(_zulu_color yellow "Usage:")
+  builtin echo "  zulu fpath <context> <dir>"
+  builtin echo
+  builtin echo $(_zulu_color yellow "Context:")
+  builtin echo "  add <dir>   Add a directory to \$fpath"
+  builtin echo "  reset       Replace the current session \$fpath with the stored dirs"
+  builtin echo "  rm <dir>    Remove a directory from \$fpath"
 }
 
 ###
@@ -21,13 +21,13 @@ function _zulu_fpath_parse() {
   if [[ -d "$PWD/$dir" ]]; then
     # If the directory exists in the current working directory
     # convert the relative path to absolute
-    echo "$PWD/$dir"
+    builtin echo "$PWD/$dir"
   elif [[ -d "$dir" ]]; then
     # If the directory exists as an absolute path, we can use it directly
-    echo "$dir"
+    builtin echo "$dir"
   elif [[ "$check_existing" != "false" ]]; then
     # The directory could not be found
-    echo $dir
+    builtin echo $dir
     return 1
   fi
 }
@@ -37,7 +37,7 @@ function _zulu_fpath_parse() {
 ###
 function _zulu_fpath_add() {
   local dir p
-  local -a items paths; paths=($(cat $pathfile))
+  local -a items paths; paths=($(command cat $pathfile))
 
   # Check that each of the passed directories exist, and convert relative
   # paths to absolute
@@ -49,9 +49,9 @@ function _zulu_fpath_add() {
       # Add the directory to the array of items
       items+="$dir"
 
-      echo "$(_zulu_color green '✔') $dir added to \$fpath"
+      builtin echo "$(_zulu_color green '✔') $dir added to \$fpath"
     else
-      echo "$(_zulu_color red '✘') $dir cannot be found"
+      builtin echo "$(_zulu_color red '✘') $dir cannot be found"
     fi
 
   done
@@ -71,7 +71,7 @@ function _zulu_fpath_add() {
 ###
 function _zulu_fpath_rm() {
   local dir p
-  local -a items paths; paths=($(cat $pathfile))
+  local -a items paths; paths=($(command cat $pathfile))
 
   # Check that each of the passed directories exist, and convert relative
   # paths to absolute
@@ -80,7 +80,7 @@ function _zulu_fpath_rm() {
 
     # If parsing returned with an error, output the error and return
     if [[ ! $? -eq 0 ]]; then
-      echo $dir
+      builtin echo $dir
       return 1
     fi
 
@@ -92,7 +92,7 @@ function _zulu_fpath_rm() {
       fi
     done
 
-    echo "$(_zulu_color green '✔') $dir removed from \$fpath"
+    builtin echo "$(_zulu_color green '✔') $dir removed from \$fpath"
   done
 
   # Store the new paths in the pathfile, and override $fpath
@@ -110,9 +110,9 @@ function _zulu_fpath_store() {
   separator=$'\n'
   local oldIFS=$IFS
   IFS="$separator"; out="${items[*]/#/${separator}}"
-  echo ${out:${#separator}} >! $pathfile
+  builtin echo ${out:${#separator}} >! $pathfile
   IFS=$oldIFS
-  unset oldIFS
+  builtin unset oldIFS
 }
 
 ###
@@ -120,7 +120,7 @@ function _zulu_fpath_store() {
 ###
 function _zulu_fpath_reset() {
   local separator out
-  local -a paths; paths=($(cat $pathfile))
+  local -a paths; paths=($(command cat $pathfile))
 
   typeset -gUa fpath; fpath=()
   for p in "${paths[@]}"; do
@@ -135,7 +135,7 @@ function _zulu_fpath() {
   local ctx base pathfile
 
   # Parse options
-  zparseopts -D h=help -help=help
+  builtin zparseopts -D h=help -help=help
 
   # Output help and return if requested
   if [[ -n $help ]]; then
@@ -150,7 +150,7 @@ function _zulu_fpath() {
 
   # If no context is passed, output the contents of the pathfile
   if [[ "$1" = "" ]]; then
-    cat "$pathfile"
+    command cat "$pathfile"
     return
   fi
 

--- a/src/commands/func.zsh
+++ b/src/commands/func.zsh
@@ -2,14 +2,14 @@
 # Output usage information
 ###
 function _zulu_func_usage() {
-  echo $(_zulu_color yellow "Usage:")
-  echo "  zulu func <context>"
-  echo
-  echo $(_zulu_color yellow "Contexts:")
-  echo "  add <function>    Add a function"
-  echo "  edit <function>   Edit a function"
-  echo "  load              Load all functions from functions directory"
-  echo "  rm <function>     Remove a function"
+  builtin echo $(_zulu_color yellow "Usage:")
+  builtin echo "  zulu func <context>"
+  builtin echo
+  builtin echo $(_zulu_color yellow "Contexts:")
+  builtin echo "  add <function>    Add a function"
+  builtin echo "  edit <function>   Edit a function"
+  builtin echo "  load              Load all functions from functions directory"
+  builtin echo "  rm <function>     Remove a function"
 }
 
 ###
@@ -21,16 +21,16 @@ _zulu_func_add() {
   func="$1"
 
   if [[ -z $EDITOR ]]; then
-    echo $(_zulu_color red "The \$EDITOR environment variable must be set to use the func command in add or edit context")
+    builtin echo $(_zulu_color red "The \$EDITOR environment variable must be set to use the func command in add or edit context")
     return 1
   fi
 
   if [[ -f "$funcdir/$func" ]]; then
-    echo $(_zulu_color red "Function '$func' already exists")
+    builtin echo $(_zulu_color red "Function '$func' already exists")
     return 1
   fi
 
-  echo "#!/usr/bin/env zsh
+  builtin echo "#!/usr/bin/env zsh
 
 (( \$+functions[$func] )) || function $func() {
 
@@ -51,12 +51,12 @@ _zulu_func_edit() {
   func="$1"
 
   if [[ -z $EDITOR ]]; then
-    echo $(_zulu_color red "The \$EDITOR environment variable must be set to use the func command in add or edit context")
+    builtin echo $(_zulu_color red "The \$EDITOR environment variable must be set to use the func command in add or edit context")
     return 1
   fi
 
   if [[ ! -f "$funcdir/$func" ]]; then
-    echo $(_zulu_color red "Function '$func' does not exist")
+    builtin echo $(_zulu_color red "Function '$func' does not exist")
     return 1
   fi
 
@@ -75,12 +75,12 @@ _zulu_func_rm() {
   func="$1"
 
   if [[ ! -f "$funcdir/$func" ]]; then
-    echo $(_zulu_color red "Function '$alias' does not exist")
+    builtin echo $(_zulu_color red "Function '$alias' does not exist")
     return 1
   fi
 
   unfunction $func
-  rm "$funcdir/$func"
+  command rm "$funcdir/$func"
   zulu func load
   return
 }
@@ -91,7 +91,7 @@ _zulu_func_rm() {
 _zulu_func_load() {
   for f in $(ls $funcdir); do
     (( $+functions[$f] )) && unfunction $f
-    source "$funcdir/$f"
+    builtin source "$funcdir/$f"
   done
 }
 
@@ -102,7 +102,7 @@ function _zulu_func() {
   local ctx base funcdir
 
   # Parse options
-  zparseopts -D h=help -help=help
+  builtin zparseopts -D h=help -help=help
 
   # Output help and return if requested
   if [[ -n $help ]]; then
@@ -118,12 +118,12 @@ function _zulu_func() {
   # Check for and create the directory, since it will not
   # exist in older versions of Zulu
   if [[ ! -d "$funcdir" ]]; then
-    mkdir -p "$funcdir"
+    command mkdir -p "$funcdir"
   fi
 
   # If no context is passed, output the contents of the aliasfile
   if [[ "$1" = "" ]]; then
-    ls "$funcdir"
+    command ls "$funcdir"
     return
   fi
 

--- a/src/commands/info.zsh
+++ b/src/commands/info.zsh
@@ -2,8 +2,8 @@
 # Output usage information
 ###
 function _zulu_info_usage() {
-  echo $(_zulu_color yellow "Usage:")
-  echo "  zulu info <package>"
+  builtin echo $(_zulu_color yellow "Usage:")
+  builtin echo "  zulu info <package>"
 }
 
 ###
@@ -22,7 +22,7 @@ function _zulu_info_is_installed() {
 function _zulu_info_package() {
   local json name description url author packagetype installed package=$1
 
-  json=$(cat "$index/$package")
+  json=$(command cat "$index/$package")
 
   name=$(jsonval $json 'name')
   description=$(jsonval $json 'description')
@@ -32,13 +32,13 @@ function _zulu_info_package() {
 
   _zulu_info_is_installed $name && installed="$(_zulu_color green '✔ Installed')"
 
-  echo "$(_zulu_color white underline "$name") $installed"
-  echo $description
-  echo
+  builtin echo "$(_zulu_color white underline "$name") $installed"
+  builtin echo $description
+  builtin echo
 
-  echo "Type:   $packagetype"
-  echo "URL:    $url"
-  echo "Author: $author"
+  builtin echo "Type:   $packagetype"
+  builtin echo "URL:    $url"
+  builtin echo "Author: $author"
 }
 
 ###
@@ -48,7 +48,7 @@ function _zulu_info() {
   local base index out package=$1
 
   # Parse options
-  zparseopts -D h=help -help=help
+  builtin zparseopts -D h=help -help=help
 
   # Output help and return if requested
   if [[ -n $help ]]; then
@@ -62,7 +62,7 @@ function _zulu_info() {
   index="${base}/index/packages"
 
   if [[ ! -f "$index/$package" ]]; then
-    echo $(_zulu_color red "Package '$package' is not in the index")
+    builtin echo $(_zulu_color red "Package '$package' is not in the index")
     return 1
   fi
 

--- a/src/commands/init.zsh
+++ b/src/commands/init.zsh
@@ -1,12 +1,12 @@
 function _zulu_init_usage() {
-  echo $(_zulu_color yellow "Usage:")
-  echo "  zulu init [options]"
-  echo
-  echo $(_zulu_color yellow "Options:")
-  echo "  -c, --check-for-update   Check for updates on startup"
-  echo "  -h, --help               Output this help text and exit"
-  echo "  -n, --no-compile         Skip compilation of scripts on startup"
-  echo "      --dev                Start Zulu in Development Mode"
+  builtin echo $(_zulu_color yellow "Usage:")
+  builtin echo "  zulu init [options]"
+  builtin echo
+  builtin echo $(_zulu_color yellow "Options:")
+  builtin echo "  -c, --check-for-update   Check for updates on startup"
+  builtin echo "  -h, --help               Output this help text and exit"
+  builtin echo "  -n, --no-compile         Skip compilation of scripts on startup"
+  builtin echo "      --dev                Start Zulu in Development Mode"
 }
 
 function _zulu_init_setup_completion() {
@@ -24,89 +24,89 @@ function _zulu_init_setup_completion() {
   fi
 
   # Load and initialize the completion system ignoring insecure directories.
-  autoload -Uz compinit && compinit -i
+  builtin autoload -Uz compinit && compinit -i
 
   #
   # Options
   #
 
-  setopt COMPLETE_IN_WORD    # Complete from both ends of a word.
-  setopt ALWAYS_TO_END       # Move cursor to the end of a completed word.
-  setopt PATH_DIRS           # Perform path search even on command names with slashes.
-  setopt AUTO_MENU           # Show completion menu on a successive tab press.
-  setopt AUTO_LIST           # Automatically list choices on ambiguous completion.
-  setopt AUTO_PARAM_SLASH    # If completed parameter is a directory, add a trailing slash.
-  unsetopt MENU_COMPLETE     # Do not autoselect the first completion entry.
-  unsetopt FLOW_CONTROL      # Disable start/stop characters in shell editor.
+  builtin setopt COMPLETE_IN_WORD    # Complete from both ends of a word.
+  builtin setopt ALWAYS_TO_END       # Move cursor to the end of a completed word.
+  builtin setopt PATH_DIRS           # Perform path search even on command names with slashes.
+  builtin setopt AUTO_MENU           # Show completion menu on a successive tab press.
+  builtin setopt AUTO_LIST           # Automatically list choices on ambiguous completion.
+  builtin setopt AUTO_PARAM_SLASH    # If completed parameter is a directory, add a trailing slash.
+  builtin unsetopt MENU_COMPLETE     # Do not autoselect the first completion entry.
+  builtin unsetopt FLOW_CONTROL      # Disable start/stop characters in shell editor.
 
   #
   # Styles
   #
 
   # Use caching to make completion for commands such as dpkg and apt usable.
-  zstyle ':completion::complete:*' use-cache on
-  zstyle ':completion::complete:*' cache-path "${ZDOTDIR:-$HOME}/.zcompcache"
+  builtin zstyle ':completion::complete:*' use-cache on
+  builtin zstyle ':completion::complete:*' cache-path "${ZDOTDIR:-$HOME}/.zcompcache"
 
   # Disable case sensitivity
-  zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}' 'r:|[._-]=* r:|=*' 'l:|=* r:|=*'
-  unsetopt CASE_GLOB
+  builtin zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}' 'r:|[._-]=* r:|=*' 'l:|=* r:|=*'
+  builtin unsetopt CASE_GLOB
 
   # Group matches and describe.
-  zstyle ':completion:*:*:*:*:*' menu select
-  zstyle ':completion:*:matches' group 'yes'
-  zstyle ':completion:*:options' description 'yes'
-  zstyle ':completion:*:options' auto-description '%d'
-  zstyle ':completion:*:corrections' format ' %F{green}-- %d (errors: %e) --%f'
-  zstyle ':completion:*:descriptions' format ' %F{yellow}-- %d --%f'
-  zstyle ':completion:*:messages' format ' %F{purple} -- %d --%f'
-  zstyle ':completion:*:warnings' format ' %F{red}-- no matches found --%f'
-  zstyle ':completion:*:default' list-prompt '%S%M matches%s'
-  zstyle ':completion:*' format ' %F{yellow}-- %d --%f'
-  zstyle ':completion:*' group-name ''
-  zstyle ':completion:*' verbose yes
+  builtin zstyle ':completion:*:*:*:*:*' menu select
+  builtin zstyle ':completion:*:matches' group 'yes'
+  builtin zstyle ':completion:*:options' description 'yes'
+  builtin zstyle ':completion:*:options' auto-description '%d'
+  builtin zstyle ':completion:*:corrections' format ' %F{green}-- %d (errors: %e) --%f'
+  builtin zstyle ':completion:*:descriptions' format ' %F{yellow}-- %d --%f'
+  builtin zstyle ':completion:*:messages' format ' %F{purple} -- %d --%f'
+  builtin zstyle ':completion:*:warnings' format ' %F{red}-- no matches found --%f'
+  builtin zstyle ':completion:*:default' list-prompt '%S%M matches%s'
+  builtin zstyle ':completion:*' format ' %F{yellow}-- %d --%f'
+  builtin zstyle ':completion:*' group-name ''
+  builtin zstyle ':completion:*' verbose yes
 
   # Don't show already completed options in the list
-  zstyle ':completion:*:*:*:*:*' ignore-line 'yes'
+  builtin zstyle ':completion:*:*:*:*:*' ignore-line 'yes'
 
   # Fuzzy match mistyped completions.
-  zstyle ':completion:*' completer _complete _match _approximate
-  zstyle ':completion:*:match:*' original only
-  zstyle ':completion:*:approximate:*' max-errors 1 numeric
+  builtin zstyle ':completion:*' completer _complete _match _approximate
+  builtin zstyle ':completion:*:match:*' original only
+  builtin zstyle ':completion:*:approximate:*' max-errors 1 numeric
 
   # Increase the number of errors based on the length of the typed word.
-  zstyle -e ':completion:*:approximate:*' max-errors 'reply=($((($#PREFIX+$#SUFFIX)/3))numeric)'
+  builtin zstyle -e ':completion:*:approximate:*' max-errors 'reply=($((($#PREFIX+$#SUFFIX)/3))numeric)'
 
   # Don't complete unavailable commands.
-  zstyle ':completion:*:functions' ignored-patterns '(_*|pre(cmd|exec))'
+  builtin zstyle ':completion:*:functions' ignored-patterns '(_*|pre(cmd|exec))'
 
   # Array completion element sorting.
-  zstyle ':completion:*:*:-subscript-:*' tag-order indexes parameters
+  builtin zstyle ':completion:*:*:-subscript-:*' tag-order indexes parameters
 
   # Directories
-  zstyle ':completion:*:default' list-colors ${(s.:.)LS_COLORS}
-  zstyle ':completion:*:*:cd:*' tag-order local-directories directory-stack path-directories
-  zstyle ':completion:*:*:cd:*:directory-stack' menu yes select
-  zstyle ':completion:*:-tilde-:*' group-order 'named-directories' 'path-directories' 'users' 'expand'
-  zstyle ':completion:*' squeeze-slashes true
+  builtin zstyle ':completion:*:default' list-colors ${(s.:.)LS_COLORS}
+  builtin zstyle ':completion:*:*:cd:*' tag-order local-directories directory-stack path-directories
+  builtin zstyle ':completion:*:*:cd:*:directory-stack' menu yes select
+  builtin zstyle ':completion:*:-tilde-:*' group-order 'named-directories' 'path-directories' 'users' 'expand'
+  builtin zstyle ':completion:*' squeeze-slashes true
 
   # History
-  zstyle ':completion:*:history-words' stop yes
-  zstyle ':completion:*:history-words' remove-all-dups yes
-  zstyle ':completion:*:history-words' list false
-  zstyle ':completion:*:history-words' menu yes
+  builtin zstyle ':completion:*:history-words' stop yes
+  builtin zstyle ':completion:*:history-words' remove-all-dups yes
+  builtin zstyle ':completion:*:history-words' list false
+  builtin zstyle ':completion:*:history-words' menu yes
 
   # Environmental Variables
-  zstyle ':completion::*:(-command-|export):*' fake-parameters ${${${_comps[(I)-value-*]#*,}%%,*}:#-*-}
+  builtin zstyle ':completion::*:(-command-|export):*' fake-parameters ${${${_comps[(I)-value-*]#*,}%%,*}:#-*-}
 
   # Populate hostname completion.
-  zstyle -e ':completion:*:hosts' hosts 'reply=(
+  builtin zstyle -e ':completion:*:hosts' hosts 'reply=(
     ${=${=${=${${(f)"$(cat {/etc/ssh_,~/.ssh/known_}hosts(|2)(N) 2>/dev/null)"}%%[#| ]*}//\]:[0-9]*/ }//,/ }//\[/ }
     ${=${(f)"$(cat /etc/hosts(|)(N) <<(ypcat hosts 2>/dev/null))"}%%\#*}
     ${=${${${${(@M)${(f)"$(cat ~/.ssh/config 2>/dev/null)"}:#Host *}#Host }:#*\**}:#*\?*}}
   )'
 
   # Don't complete uninteresting users...
-  zstyle ':completion:*:*:*:users' ignored-patterns \
+  builtin zstyle ':completion:*:*:*:users' ignored-patterns \
     adm amanda apache avahi beaglidx bin cacti canna clamav daemon \
     dbus distcache dovecot fax ftp games gdm gkrellmd gopher \
     hacluster haldaemon halt hsqldb ident junkbust ldap lp mail \
@@ -116,43 +116,43 @@ function _zulu_init_setup_completion() {
     rpc rpcuser rpm shutdown squid sshd sync uucp vcsa xfs '_*'
 
   # ... unless we really want to.
-  zstyle '*' single-ignored show
+  builtin zstyle '*' single-ignored show
 
   # Ignore multiple entries.
-  zstyle ':completion:*:(rm|kill|diff):*' ignore-line other
-  zstyle ':completion:*:rm:*' file-patterns '*:all-files'
+  builtin zstyle ':completion:*:(rm|kill|diff):*' ignore-line other
+  builtin zstyle ':completion:*:rm:*' file-patterns '*:all-files'
 
   # Kill
-  zstyle ':completion:*:*:*:*:processes' command 'ps -u $LOGNAME -o pid,user,command -w'
-  zstyle ':completion:*:*:kill:*:processes' list-colors '=(#b) #([0-9]#) ([0-9a-z-]#)*=01;36=0=01'
-  zstyle ':completion:*:*:kill:*' menu yes select
-  zstyle ':completion:*:*:kill:*' force-list always
-  zstyle ':completion:*:*:kill:*' insert-ids single
+  builtin zstyle ':completion:*:*:*:*:processes' command 'ps -u $LOGNAME -o pid,user,command -w'
+  builtin zstyle ':completion:*:*:kill:*:processes' list-colors '=(#b) #([0-9]#) ([0-9a-z-]#)*=01;36=0=01'
+  builtin zstyle ':completion:*:*:kill:*' menu yes select
+  builtin zstyle ':completion:*:*:kill:*' force-list always
+  builtin zstyle ':completion:*:*:kill:*' insert-ids single
 
   # Man
-  zstyle ':completion:*:manuals' separate-sections true
-  zstyle ':completion:*:manuals.(^1*)' insert-sections true
+  builtin zstyle ':completion:*:manuals' separate-sections true
+  builtin zstyle ':completion:*:manuals.(^1*)' insert-sections true
 
   # Media Players
-  zstyle ':completion:*:*:mpg123:*' file-patterns '*.(mp3|MP3):mp3\ files *(-/):directories'
-  zstyle ':completion:*:*:mpg321:*' file-patterns '*.(mp3|MP3):mp3\ files *(-/):directories'
-  zstyle ':completion:*:*:ogg123:*' file-patterns '*.(ogg|OGG|flac):ogg\ files *(-/):directories'
-  zstyle ':completion:*:*:mocp:*' file-patterns '*.(wav|WAV|mp3|MP3|ogg|OGG|flac):ogg\ files *(-/):directories'
+  builtin zstyle ':completion:*:*:mpg123:*' file-patterns '*.(mp3|MP3):mp3\ files *(-/):directories'
+  builtin zstyle ':completion:*:*:mpg321:*' file-patterns '*.(mp3|MP3):mp3\ files *(-/):directories'
+  builtin zstyle ':completion:*:*:ogg123:*' file-patterns '*.(ogg|OGG|flac):ogg\ files *(-/):directories'
+  builtin zstyle ':completion:*:*:mocp:*' file-patterns '*.(wav|WAV|mp3|MP3|ogg|OGG|flac):ogg\ files *(-/):directories'
 
   # Mutt
   if [[ -s "$HOME/.mutt/aliases" ]]; then
-    zstyle ':completion:*:*:mutt:*' menu yes select
-    zstyle ':completion:*:mutt:*' users ${${${(f)"$(<"$HOME/.mutt/aliases")"}#alias[[:space:]]}%%[[:space:]]*}
+    builtin zstyle ':completion:*:*:mutt:*' menu yes select
+    builtin zstyle ':completion:*:mutt:*' users ${${${(f)"$(<"$HOME/.mutt/aliases")"}#alias[[:space:]]}%%[[:space:]]*}
   fi
 
   # SSH/SCP/RSYNC
-  zstyle ':completion:*:(scp|rsync):*' tag-order 'hosts:-host:host hosts:-domain:domain hosts:-ipaddr:ip\ address *'
-  zstyle ':completion:*:(scp|rsync):*' group-order users files all-files hosts-domain hosts-host hosts-ipaddr
-  zstyle ':completion:*:ssh:*' tag-order 'hosts:-host:host hosts:-domain:domain hosts:-ipaddr:ip\ address *'
-  zstyle ':completion:*:ssh:*' group-order users hosts-domain hosts-host users hosts-ipaddr
-  zstyle ':completion:*:(ssh|scp|rsync):*:hosts-host' ignored-patterns '*(.|:)*' loopback ip6-loopback localhost ip6-localhost broadcasthost
-  zstyle ':completion:*:(ssh|scp|rsync):*:hosts-domain' ignored-patterns '<->.<->.<->.<->' '^[-[:alnum:]]##(.[-[:alnum:]]##)##' '*@*'
-  zstyle ':completion:*:(ssh|scp|rsync):*:hosts-ipaddr' ignored-patterns '^(<->.<->.<->.<->|(|::)([[:xdigit:].]##:(#c,2))##(|%*))' '127.0.0.<->' '255.255.255.255' '::1' 'fe80::*'
+  builtin zstyle ':completion:*:(scp|rsync):*' tag-order 'hosts:-host:host hosts:-domain:domain hosts:-ipaddr:ip\ address *'
+  builtin zstyle ':completion:*:(scp|rsync):*' group-order users files all-files hosts-domain hosts-host hosts-ipaddr
+  builtin zstyle ':completion:*:ssh:*' tag-order 'hosts:-host:host hosts:-domain:domain hosts:-ipaddr:ip\ address *'
+  builtin zstyle ':completion:*:ssh:*' group-order users hosts-domain hosts-host users hosts-ipaddr
+  builtin zstyle ':completion:*:(ssh|scp|rsync):*:hosts-host' ignored-patterns '*(.|:)*' loopback ip6-loopback localhost ip6-localhost broadcasthost
+  builtin zstyle ':completion:*:(ssh|scp|rsync):*:hosts-domain' ignored-patterns '<->.<->.<->.<->' '^[-[:alnum:]]##(.[-[:alnum:]]##)##' '*@*'
+  builtin zstyle ':completion:*:(ssh|scp|rsync):*:hosts-ipaddr' ignored-patterns '^(<->.<->.<->.<->|(|::)([[:xdigit:].]##:(#c,2))##(|%*))' '127.0.0.<->' '255.255.255.255' '::1' 'fe80::*'
 }
 
 function _zulu_init_setup_history() {
@@ -168,18 +168,18 @@ function _zulu_init_setup_history() {
   # Options
   #
 
-  setopt BANG_HIST                 # Treat the '!' character specially during expansion.
-  setopt EXTENDED_HISTORY          # Write the history file in the ':start:elapsed;command' format.
-  setopt INC_APPEND_HISTORY        # Write to the history file immediately, not when the shell exits.
-  setopt SHARE_HISTORY             # Share history between all sessions.
-  setopt HIST_EXPIRE_DUPS_FIRST    # Expire a duplicate event first when trimming history.
-  setopt HIST_IGNORE_DUPS          # Do not record an event that was just recorded again.
-  setopt HIST_IGNORE_ALL_DUPS      # Delete an old recorded event if a new event is a duplicate.
-  setopt HIST_FIND_NO_DUPS         # Do not display a previously found event.
-  setopt HIST_IGNORE_SPACE         # Do not record an event starting with a space.
-  setopt HIST_SAVE_NO_DUPS         # Do not write a duplicate event to the history file.
-  setopt HIST_VERIFY               # Do not execute immediately upon history expansion.
-  setopt HIST_BEEP                 # Beep when accessing non-existent history.
+  builtin setopt BANG_HIST                 # Treat the '!' character specially during expansion.
+  builtin setopt EXTENDED_HISTORY          # Write the history file in the ':start:elapsed;command' format.
+  builtin setopt INC_APPEND_HISTORY        # Write to the history file immediately, not when the shell exits.
+  builtin setopt SHARE_HISTORY             # Share history between all sessions.
+  builtin setopt HIST_EXPIRE_DUPS_FIRST    # Expire a duplicate event first when trimming history.
+  builtin setopt HIST_IGNORE_DUPS          # Do not record an event that was just recorded again.
+  builtin setopt HIST_IGNORE_ALL_DUPS      # Delete an old recorded event if a new event is a duplicate.
+  builtin setopt HIST_FIND_NO_DUPS         # Do not display a previously found event.
+  builtin setopt HIST_IGNORE_SPACE         # Do not record an event starting with a space.
+  builtin setopt HIST_SAVE_NO_DUPS         # Do not write a duplicate event to the history file.
+  builtin setopt HIST_VERIFY               # Do not execute immediately upon history expansion.
+  builtin setopt HIST_BEEP                 # Beep when accessing non-existent history.
 
   if (( $+widgets[history-substring-search-up] )); then
     #
@@ -193,8 +193,8 @@ function _zulu_init_setup_history() {
     # Source module files.
     [[ -f "$base/init/zsh-history-substring-search.zsh" ]] || return 1
 
-    zle -N history-substring-search-up
-    zle -N history-substring-search-down
+    builtin zle -N history-substring-search-up
+    builtin zle -N history-substring-search-down
 
     #
     # Search
@@ -211,17 +211,17 @@ function _zulu_init_setup_history() {
 
     if [[ -n "$key_info" ]]; then
       # Emacs
-      bindkey -M emacs "$key_info[Control]P" history-substring-search-up
-      bindkey -M emacs "$key_info[Control]N" history-substring-search-down
+      builtin bindkey -M emacs "$key_info[Control]P" history-substring-search-up
+      builtin bindkey -M emacs "$key_info[Control]N" history-substring-search-down
 
       # Vi
-      bindkey -M vicmd "k" history-substring-search-up
-      bindkey -M vicmd "j" history-substring-search-down
+      builtin bindkey -M vicmd "k" history-substring-search-up
+      builtin bindkey -M vicmd "j" history-substring-search-down
 
       # Emacs and Vi
       for keymap in 'emacs' 'viins'; do
-        bindkey -M "$keymap" "$key_info[Up]" history-substring-search-up
-        bindkey -M "$keymap" "$key_info[Down]" history-substring-search-down
+        builtin bindkey -M "$keymap" "$key_info[Up]" history-substring-search-up
+        builtin bindkey -M "$keymap" "$key_info[Down]" history-substring-search-down
       done
     fi
   fi
@@ -245,7 +245,7 @@ function _zulu_init_setup_key_bindings() {
   #
 
   # Beep on error in line editor.
-  setopt BEEP
+  builtin setopt BEEP
 
   #
   # Variables
@@ -255,7 +255,7 @@ function _zulu_init_setup_key_bindings() {
   WORDCHARS='*?_-.[]~&;!#$%^(){}<>'
 
   # Use human-friendly identifiers.
-  zmodload zsh/terminfo
+  builtin zmodload zsh/terminfo
   typeset -gA key_info
   key_info=(
     'Control'      '\C-'
@@ -302,8 +302,8 @@ function _zulu_init_setup_key_bindings() {
   #
 
   # Allow command line editing in an external editor.
-  autoload -Uz edit-command-line
-  zle -N edit-command-line
+  builtin autoload -Uz edit-command-line
+  builtin zle -N edit-command-line
 
   #
   # Functions
@@ -312,16 +312,16 @@ function _zulu_init_setup_key_bindings() {
   # Exposes information about the Zsh Line Editor via the $editor_info associative
   # array.
   function editor-info {
-    zle reset-prompt
-    zle -R
+    builtin zle reset-prompt
+    builtin zle -R
   }
-  zle -N editor-info
+  builtin zle -N editor-info
 
   # Updates editor information when the keymap changes.
   function zle-keymap-select {
-    zle editor-info
+    builtin zle editor-info
   }
-  zle -N zle-keymap-select
+  builtin zle -N zle-keymap-select
 
   # Enables terminal application mode and updates editor information.
   function zle-line-init {
@@ -333,9 +333,9 @@ function _zulu_init_setup_key_bindings() {
     fi
 
     # Update editor information.
-    zle editor-info
+    builtin zle editor-info
   }
-  zle -N zle-line-init
+  builtin zle -N zle-line-init
 
   # Disables terminal application mode and updates editor information.
   function zle-line-finish {
@@ -347,38 +347,38 @@ function _zulu_init_setup_key_bindings() {
     fi
 
     # Update editor information.
-    zle editor-info
+    builtin zle editor-info
   }
-  zle -N zle-line-finish
+  builtin zle -N zle-line-finish
 
   # Toggles emacs overwrite mode and updates editor information.
   function overwrite-mode {
-    zle .overwrite-mode
-    zle editor-info
+    builtin zle .overwrite-mode
+    builtin zle editor-info
   }
-  zle -N overwrite-mode
+  builtin zle -N overwrite-mode
 
   # Enters vi insert mode and updates editor information.
   function vi-insert {
-    zle .vi-insert
-    zle editor-info
+    builtin zle .vi-insert
+    builtin zle editor-info
   }
-  zle -N vi-insert
+  builtin zle -N vi-insert
 
   # Moves to the first non-blank character then enters vi insert mode and updates
   # editor information.
   function vi-insert-bol {
-    zle .vi-insert-bol
-    zle editor-info
+    builtin zle .vi-insert-bol
+    builtin zle editor-info
   }
-  zle -N vi-insert-bol
+  builtin zle -N vi-insert-bol
 
   # Enters vi replace mode and updates editor information.
   function vi-replace  {
-    zle .vi-replace
-    zle editor-info
+    builtin zle .vi-replace
+    builtin zle editor-info
   }
-  zle -N vi-replace
+  builtin zle -N vi-replace
 
   # Expands .... to ../..
   function expand-dot-to-parent-directory-path {
@@ -388,16 +388,16 @@ function _zulu_init_setup_key_bindings() {
       LBUFFER+='.'
     fi
   }
-  zle -N expand-dot-to-parent-directory-path
+  builtin zle -N expand-dot-to-parent-directory-path
 
   # Displays an indicator when completing.
   function expand-or-complete-with-indicator {
     local indicator="→"
     print -Pn "$indicator"
-    zle expand-or-complete
-    zle redisplay
+    builtin zle expand-or-complete
+    builtin zle redisplay
   }
-  zle -N expand-or-complete-with-indicator
+  builtin zle -N expand-or-complete-with-indicator
 
   # Inserts 'sudo ' at the beginning of the line.
   function prepend-sudo {
@@ -406,40 +406,40 @@ function _zulu_init_setup_key_bindings() {
       (( CURSOR += 5 ))
     fi
   }
-  zle -N prepend-sudo
+  builtin zle -N prepend-sudo
 
   # Reset to default key bindings.
-  bindkey -d
+  builtin bindkey -d
 
   #
   # Emacs Key Bindings
   #
 
   for key in "$key_info[Escape]"{B,b} "${(s: :)key_info[ControlLeft]}"
-    bindkey -M emacs "$key" emacs-backward-word
+    builtin bindkey -M emacs "$key" emacs-backward-word
   for key in "$key_info[Escape]"{F,f} "${(s: :)key_info[ControlRight]}"
-    bindkey -M emacs "$key" emacs-forward-word
+    builtin bindkey -M emacs "$key" emacs-forward-word
 
   # Kill to the beginning of the line.
   for key in "$key_info[Escape]"{K,k}
-    bindkey -M emacs "$key" backward-kill-line
+    builtin bindkey -M emacs "$key" backward-kill-line
 
   # Redo.
-  bindkey -M emacs "$key_info[Escape]_" redo
+  builtin bindkey -M emacs "$key_info[Escape]_" redo
 
   # Search previous character.
-  bindkey -M emacs "$key_info[Control]X$key_info[Control]B" vi-find-prev-char
+  builtin bindkey -M emacs "$key_info[Control]X$key_info[Control]B" vi-find-prev-char
 
   # Match bracket.
-  bindkey -M emacs "$key_info[Control]X$key_info[Control]]" vi-match-bracket
+  builtin bindkey -M emacs "$key_info[Control]X$key_info[Control]]" vi-match-bracket
 
   # Edit command in an external editor.
-  bindkey -M emacs "$key_info[Control]X$key_info[Control]E" edit-command-line
+  builtin bindkey -M emacs "$key_info[Control]X$key_info[Control]E" edit-command-line
 
   if (( $+widgets[history-incremental-pattern-search-backward] )); then
-    bindkey -M emacs "$key_info[Control]R" \
+    builtin bindkey -M emacs "$key_info[Control]R" \
       history-incremental-pattern-search-backward
-    bindkey -M emacs "$key_info[Control]S" \
+    builtin bindkey -M emacs "$key_info[Control]S" \
       history-incremental-pattern-search-forward
   fi
 
@@ -448,18 +448,18 @@ function _zulu_init_setup_key_bindings() {
   #
 
   # Edit command in an external editor.
-  bindkey -M vicmd "v" edit-command-line
+  builtin bindkey -M vicmd "v" edit-command-line
 
   # Undo/Redo
-  bindkey -M vicmd "u" undo
-  bindkey -M vicmd "$key_info[Control]R" redo
+  builtin bindkey -M vicmd "u" undo
+  builtin bindkey -M vicmd "$key_info[Control]R" redo
 
   if (( $+widgets[history-incremental-pattern-search-backward] )); then
-    bindkey -M vicmd "?" history-incremental-pattern-search-backward
-    bindkey -M vicmd "/" history-incremental-pattern-search-forward
+    builtin bindkey -M vicmd "?" history-incremental-pattern-search-backward
+    builtin bindkey -M vicmd "/" history-incremental-pattern-search-forward
   else
-    bindkey -M vicmd "?" history-incremental-search-backward
-    bindkey -M vicmd "/" history-incremental-search-forward
+    builtin bindkey -M vicmd "?" history-incremental-search-backward
+    builtin bindkey -M vicmd "/" history-incremental-search-forward
   fi
 
   #
@@ -467,52 +467,52 @@ function _zulu_init_setup_key_bindings() {
   #
 
   for keymap in 'emacs' 'viins'; do
-    bindkey -M "$keymap" "$key_info[Home]" beginning-of-line
-    bindkey -M "$keymap" "$key_info[End]" end-of-line
+    builtin bindkey -M "$keymap" "$key_info[Home]" beginning-of-line
+    builtin bindkey -M "$keymap" "$key_info[End]" end-of-line
 
-    bindkey -M "$keymap" "$key_info[Insert]" overwrite-mode
-    bindkey -M "$keymap" "$key_info[Delete]" delete-char
-    bindkey -M "$keymap" "$key_info[Backspace]" backward-delete-char
+    builtin bindkey -M "$keymap" "$key_info[Insert]" overwrite-mode
+    builtin bindkey -M "$keymap" "$key_info[Delete]" delete-char
+    builtin bindkey -M "$keymap" "$key_info[Backspace]" backward-delete-char
 
-    bindkey -M "$keymap" "$key_info[Left]" backward-char
-    bindkey -M "$keymap" "$key_info[Right]" forward-char
+    builtin bindkey -M "$keymap" "$key_info[Left]" backward-char
+    builtin bindkey -M "$keymap" "$key_info[Right]" forward-char
 
     # Expand history on space.
-    bindkey -M "$keymap" ' ' magic-space
+    builtin bindkey -M "$keymap" ' ' magic-space
 
     # Clear screen.
-    bindkey -M "$keymap" "$key_info[Control]L" clear-screen
+    builtin bindkey -M "$keymap" "$key_info[Control]L" clear-screen
 
     # Expand command name to full path.
     for key in "$key_info[Escape]"{E,e}
-      bindkey -M "$keymap" "$key" expand-cmd-path
+      builtin bindkey -M "$keymap" "$key" expand-cmd-path
 
     # Duplicate the previous word.
     for key in "$key_info[Escape]"{M,m}
-      bindkey -M "$keymap" "$key" copy-prev-shell-word
+      builtin bindkey -M "$keymap" "$key" copy-prev-shell-word
 
     # Use a more flexible push-line.
     for key in "$key_info[Control]Q" "$key_info[Escape]"{q,Q}
-      bindkey -M "$keymap" "$key" push-line-or-edit
+      builtin bindkey -M "$keymap" "$key" push-line-or-edit
 
     # Bind Shift + Tab to go to the previous menu item.
-    bindkey -M "$keymap" "$key_info[BackTab]" reverse-menu-complete
+    builtin bindkey -M "$keymap" "$key_info[BackTab]" reverse-menu-complete
 
     # Complete in the middle of word.
-    bindkey -M "$keymap" "$key_info[Control]I" expand-or-complete
+    builtin bindkey -M "$keymap" "$key_info[Control]I" expand-or-complete
 
     # Expand .... to ../..
-    bindkey -M "$keymap" "." expand-dot-to-parent-directory-path
+    builtin bindkey -M "$keymap" "." expand-dot-to-parent-directory-path
 
     # Display an indicator when completing.
-    bindkey -M "$keymap" "$key_info[Control]I" \
+    builtin bindkey -M "$keymap" "$key_info[Control]I" \
       expand-or-complete-with-indicator
 
     # Insert 'sudo ' at the beginning of the line.
-    bindkey -M "$keymap" "$key_info[Control]X$key_info[Control]S" prepend-sudo
+    builtin bindkey -M "$keymap" "$key_info[Control]X$key_info[Control]S" prepend-sudo
   done
 
-  unset key{,map,bindings}
+  builtin unset key{,map,bindings}
 }
 
 ###
@@ -537,21 +537,21 @@ function _zulu_check_for_update() {
       {
         out=$(${=command})
         if [[ $? -eq 0 ]]; then
-          echo $out
+          builtin echo $out
         fi
       } &!
       pids+=$!
     done
 
     for pid in $pids; do
-      while kill -0 $pid >/dev/null 2>&1; do
+      while builtin kill -0 $pid >/dev/null 2>&1; do
       done
     done
   else
     for command in $commands; do
       out=$(${=command})
       if [[ $? -eq 0 ]]; then
-        echo $out
+        builtin echo $out
       fi
     done
   fi
@@ -562,12 +562,12 @@ function _zulu_check_for_update() {
 ###
 function _zulu_load_packages() {
   # Source files in the init directory
-  setopt EXTENDED_GLOB
+  builtin setopt EXTENDED_GLOB
   for f in ${base}/init/**/*^(*.zwc)(#q@N); do
     if [[ -L $f ]]; then
-      source $(readlink $f)
+      builtin source $(command readlink $f)
     else
-      source $f
+      builtin source $f
     fi
   done
 }
@@ -577,33 +577,33 @@ function _zulu_load_packages() {
 ###
 function _zulu_init_switch_branch() {
   local oldPWD=$PWD branch="$1"
-  cd $base/core
+  builtin cd $base/core
 
-  local current=$(git status --short --branch -uno --ignore-submodules=all | head -1 | awk '{print $2}' 2>/dev/null)
+  local current=$(command git status --short --branch -uno --ignore-submodules=all | command head -1 | command awk '{print $2}' 2>/dev/null)
 
   if [[ ${current:0:${#branch}} != $branch ]]; then
-    git reset --hard >/dev/null 2>&1
-    git checkout $branch >/dev/null 2>&1
+    command git reset --hard >/dev/null 2>&1
+    command git checkout $branch >/dev/null 2>&1
     ./build.zsh >/dev/null 2>&1
-    echo "\033[0;32m✔\033[0;m Switched to Zulu ${branch}"
+    builtin echo "\033[0;32m✔\033[0;m Switched to Zulu ${branch}"
   fi
 
-  cd $oldPWD
-  unset oldPWD
+  builtin cd $oldPWD
+  builtin unset oldPWD
 }
 
 ###
 # Display a message to next users
 ###
 function _zulu_init_next_message() {
-  echo
-  echo '\033[0;33mThanks for using Zulu next\033[0;m'
-  echo 'We rely on people like you testing new versions to keep Zulu as useful'
-  echo 'and as stable as possible. If you do run into any errors, please do'
-  echo 'report them so that they can be fixed before the next release.'
-  echo
-  echo 'Github Issues: https://github.com/zulu-zsh/zulu/issues'
-  echo 'Gitter Chat:   https://gitter.im/zulu-zsh/zulu'
+  builtin echo
+  builtin echo '\033[0;33mThanks for using Zulu next\033[0;m'
+  builtin echo 'We rely on people like you testing new versions to keep Zulu as useful'
+  builtin echo 'and as stable as possible. If you do run into any errors, please do'
+  builtin echo 'report them so that they can be fixed before the next release.'
+  builtin echo
+  builtin echo 'Github Issues: https://github.com/zulu-zsh/zulu/issues'
+  builtin echo 'Gitter Chat:   https://gitter.im/zulu-zsh/zulu'
 }
 
 ###
@@ -615,7 +615,7 @@ function _zulu_init() {
   local help check_for_update no_compile next dev
 
   # Parse CLI options
-  zparseopts -D \
+  builtin zparseopts -D \
     h=help -help=help \
     c=check_for_update -check-for-update=check_for_update \
     n=no_compile -no-compile=no_compile \
@@ -666,7 +666,7 @@ function _zulu_init() {
 
   # Autoload zsh theme
   if [[ -f "$config/theme" ]]; then
-    autoload -U promptinit && promptinit
+    builtin autoload -U promptinit && promptinit
     local theme=$(cat "$config/theme")
     prompt $theme
   fi

--- a/src/commands/link.zsh
+++ b/src/commands/link.zsh
@@ -2,11 +2,11 @@
 # Print usage information
 ###
 function _zulu_link_usage() {
-  echo $(_zulu_color yellow "Usage:")
-  echo "  zulu link <package>"
-  echo
-  echo $(_zulu_color yellow "Options:")
-  echo "      --no-autoselect-themes      Don't autoselect themes after installing"
+  builtin echo $(_zulu_color yellow "Usage:")
+  builtin echo "  zulu link <package>"
+  builtin echo
+  builtin echo $(_zulu_color yellow "Options:")
+  builtin echo "      --no-autoselect-themes      Don't autoselect themes after installing"
 }
 
 ###
@@ -16,7 +16,7 @@ function _zulu_link() {
   local help package json dir file link base index no_autoselect_themes
   local -a dirs
 
-  zparseopts -D h=help -help=help \
+  builtin zparseopts -D h=help -help=help \
     -no-autoselect-themes=no_autoselect_themes
 
   if [[ -n $help ]]; then
@@ -33,32 +33,32 @@ function _zulu_link() {
   # Check if the package is already installed
   root="$base/packages/$package"
   if [[ ! -d "$root" ]]; then
-    echo $(_zulu_color red "Package '$package' is not installed")
+    builtin echo $(_zulu_color red "Package '$package' is not installed")
     return 1
   fi
 
   _zulu_revolver start "Linking $package..."
 
   # Get the JSON from the index
-  json=$(cat "$index/$package")
+  json=$(command cat "$index/$package")
 
   # See if the package has a post_install script
   post_install=$(jsonval $json 'post_install')
   if [[ -n $post_install ]]; then
     # Change to the package directory
     oldPWD=$PWD
-    cd $root
+    builtin cd $root
 
     # Eval the post_install script
-    output=$(eval "$post_install")
+    output=$(builtin eval "$post_install")
     if [[ $? -ne 0 ]]; then
-      echo $(_zulu_color red "Post install step for $package failed")
-      echo "$output"
-      cd $oldPWD
+      builtin echo $(_zulu_color red "Post install step for $package failed")
+      builtin echo "$output"
+      builtin cd $oldPWD
       return 1
     fi
 
-    cd $oldPWD
+    builtin cd $oldPWD
   fi
 
   # Loop through the 'bin' and 'share' objects
@@ -69,7 +69,7 @@ function _zulu_link() {
     IFS=$' '
 
     # Convert the bin/share object into an associative array
-    typeset -A files; files=($(echo $(jsonval $json $dir) | tr "," "\n" | tr ":" " "))
+    typeset -A files; files=($(builtin echo $(jsonval $json $dir) | tr "," "\n" | tr ":" " "))
 
     IFS=$oldIFS
 
@@ -84,12 +84,12 @@ function _zulu_link() {
 
       # Make sure that commands to be included in bin are executable
       if [[ "$dir" = "bin" ]]; then
-        chmod u+x "$root/$file"
+        command chmod u+x "$root/$file"
       fi
 
       # Source init scripts
       if [[ "$dir" = "init" ]]; then
-        source $(readlink "$base/init/$link")
+        builtin source $(command readlink "$base/init/$link")
       fi
     done
   done
@@ -102,5 +102,5 @@ function _zulu_link() {
   fi
 
   _zulu_revolver stop
-  echo "$(_zulu_color green '✔') Finished linking $package"
+  builtin echo "$(_zulu_color green '✔') Finished linking $package"
 }

--- a/src/commands/list.zsh
+++ b/src/commands/list.zsh
@@ -2,19 +2,19 @@
 # Print usage information
 ###
 function _zulu_list_usage() {
-  echo $(_zulu_color yellow "Usage:")
-  echo "  zulu list [options]"
-  echo
-  echo $(_zulu_color yellow "Options:")
-  echo "  -a, --all            List all packages in the index"
-  echo "  -d, --describe       Include package description in output"
-  echo "  -h, --help           Output this help text and exit"
-  echo "  -i, --installed      List only installed packages (default)"
-  echo "  -n, --not-installed  List non-installed packages"
-  echo "  -s, --simple         Hide the 'package installed' indicator"
-  echo "  -t, --type <type>    Limit results to packages of <type>"
-  echo "      --branch         Print the current branch (if one is checked out)"
-  echo "      --tag            Print the current tag (if one is checked out)"
+  builtin echo $(_zulu_color yellow "Usage:")
+  builtin echo "  zulu list [options]"
+  builtin echo
+  builtin echo $(_zulu_color yellow "Options:")
+  builtin echo "  -a, --all            List all packages in the index"
+  builtin echo "  -d, --describe       Include package description in output"
+  builtin echo "  -h, --help           Output this help text and exit"
+  builtin echo "  -i, --installed      List only installed packages (default)"
+  builtin echo "  -n, --not-installed  List non-installed packages"
+  builtin echo "  -s, --simple         Hide the 'package installed' indicator"
+  builtin echo "  -t, --type <type>    Limit results to packages of <type>"
+  builtin echo "      --branch         Print the current branch (if one is checked out)"
+  builtin echo "      --tag            Print the current tag (if one is checked out)"
 }
 
 ###
@@ -27,7 +27,7 @@ function _zulu_list_packages() {
   config=${ZULU_CONFIG_DIR:-"${ZDOTDIR:-$HOME}/.config/zulu"}
   index="$base/index/packages"
 
-  for package in $(/bin/ls $index); do
+  for package in $(command ls $index); do
     # If --installed is passed but the package is not installed,
     # then skip past it
     if [[ -n $installed ]] && ! _zulu_info_is_installed $package; then
@@ -43,7 +43,7 @@ function _zulu_list_packages() {
     # We only need to read the package's index file if
     # the --type or --describe options are passed
     if [[ -n $package_type || -n $describe ]]; then
-      json="$(cat $index/$package)"
+      json="$(command cat $index/$package)"
     fi
 
     # If --type is passed but the package is not of the
@@ -58,7 +58,7 @@ function _zulu_list_packages() {
 
     # Prevent ZVM from changing the ZSH version
     local old_ZVM_AUTO_USE=$ZVM_AUTO_USE
-    unset ZVM_AUTO_USE
+    builtin unset ZVM_AUTO_USE
 
     local suffix=''
 
@@ -66,38 +66,38 @@ function _zulu_list_packages() {
     # for the package and print it alongside the name
     if [[ -n $branch ]] && _zulu_info_is_installed $package; then
       local oldPWD=$PWD
-      cd "$base/packages/$package"
+      builtin cd "$base/packages/$package"
 
-      local current=$(git status --short --branch -uno --ignore-submodules=all | head -1 | awk '{print $2}' 2>/dev/null)
+      local current=$(command git status --short --branch -uno --ignore-submodules=all | command head -1 | command awk '{print $2}' 2>/dev/null)
       current=${current%...*}
 
       if [[ $current != 'HEAD' && $current != 'master' ]]; then
         suffix+=", branch: $current"
       fi
 
-      cd $oldPWD
-      unset oldPWD
+      builtin cd $oldPWD
+      builtin unset oldPWD
     fi
 
     # If --tag is specified, get the current checked-out tag
     # for the package and print it alongside the name
     if [[ -n $tag ]] && _zulu_info_is_installed $package; then
       local oldPWD=$PWD
-      cd "$base/packages/$package"
+      builtin cd "$base/packages/$package"
 
-      local commit=$(git status HEAD -uno --ignore-submodules=all | head -1 | awk '{print $4}' 2>/dev/null)
+      local commit=$(command git status HEAD -uno --ignore-submodules=all | command head -1 | command awk '{print $4}' 2>/dev/null)
 
       if [[ -n $commit ]]; then
         suffix+=", tag: $commit"
       fi
 
-      cd $oldPWD
-      unset oldPWD
+      builtin cd $oldPWD
+      builtin unset oldPWD
     fi
 
     # Restore the previous ZVM_AUTO_USE setting
     export ZVM_AUTO_USE=$old_ZVM_AUTO_USE
-    unset old_ZVM_AUTO_USE
+    builtin unset old_ZVM_AUTO_USE
 
     # Print out the name of the package, and the installed flag
     # unless --simple is passed
@@ -117,11 +117,11 @@ function _zulu_list_packages() {
     # If --describe is specified, print the description
     if [[ -n $describe ]]; then
       description=$(jsonval $json 'description')
-      printf '%s' "$name"
-      printf '%*.*s' 0 $(($lim - ${#name} )) "$(printf '%0.1s' " "{1..60})"
-      printf '%s\n' "$description"
+      builtin printf '%s' "$name"
+      builtin printf '%*.*s' 0 $(($lim - ${#name} )) "$(builtin printf '%0.1s' " "{1..60})"
+      builtin printf '%s\n' "$description"
     else
-      echo $name
+      builtin echo $name
     fi
   done
 
@@ -144,7 +144,7 @@ function _zulu_list() {
   fi
 
   # Parse options
-  zparseopts -D \
+  builtin zparseopts -D \
     h=help -help=help \
     i=installed -installed=installed \
     n=not_installed -not-installed=not_installed \
@@ -163,7 +163,7 @@ function _zulu_list() {
 
   # Check if the --type option is passed and shift the argument
   if [[ -n $package_type ]]; then
-    shift package_type
+    builtin shift package_type
   fi
 
   # List the packages

--- a/src/commands/manpath.zsh
+++ b/src/commands/manpath.zsh
@@ -2,13 +2,13 @@
 # Output usage information
 ###
 function _zulu_manpath_usage() {
-  echo $(_zulu_color yellow "Usage:")
-  echo "  zulu manpath <context> <dir>"
-  echo
-  echo $(_zulu_color yellow "Context:")
-  echo "  add <dir>   Add a directory to \$manpath"
-  echo "  reset       Replace the current session \$manpath with the stored dirs"
-  echo "  rm <dir>    Remove a directory from \$manpath"
+  builtin echo $(_zulu_color yellow "Usage:")
+  builtin echo "  zulu manpath <context> <dir>"
+  builtin echo
+  builtin echo $(_zulu_color yellow "Context:")
+  builtin echo "  add <dir>   Add a directory to \$manpath"
+  builtin echo "  reset       Replace the current session \$manpath with the stored dirs"
+  builtin echo "  rm <dir>    Remove a directory from \$manpath"
 }
 
 ###
@@ -21,13 +21,13 @@ function _zulu_manpath_parse() {
   if [[ -d "$PWD/$dir" ]]; then
     # If the directory exists in the current working directory
     # convert the relative path to absolute
-    echo "$PWD/$dir"
+    builtin echo "$PWD/$dir"
   elif [[ -d "$dir" ]]; then
     # If the directory exists as an absolute path, we can use it directly
-    echo "$dir"
+    builtin echo "$dir"
   elif [[ "$check_existing" != "false" ]]; then
     # The directory could not be found
-    echo $dir
+    builtin echo $dir
     return 1
   fi
 }
@@ -37,7 +37,7 @@ function _zulu_manpath_parse() {
 ###
 function _zulu_manpath_add() {
   local dir p
-  local -a items paths; paths=($(cat $pathfile))
+  local -a items paths; paths=($(command cat $pathfile))
 
   # Check that each of the passed directories exist, and convert relative
   # paths to absolute
@@ -49,9 +49,9 @@ function _zulu_manpath_add() {
       # Add the directory to the array of items
       items+="$dir"
 
-      echo "$(_zulu_color green '✔') $dir added to \$manpath"
+      builtin echo "$(_zulu_color green '✔') $dir added to \$manpath"
     else
-      echo "$(_zulu_color red '✘') $dir cannot be found"
+      builtin echo "$(_zulu_color red '✘') $dir cannot be found"
     fi
 
   done
@@ -71,7 +71,7 @@ function _zulu_manpath_add() {
 ###
 function _zulu_manpath_rm() {
   local dir p
-  local -a items paths; paths=($(cat $pathfile))
+  local -a items paths; paths=($(command cat $pathfile))
 
   # Check that each of the passed directories exist, and convert relative
   # paths to absolute
@@ -80,7 +80,7 @@ function _zulu_manpath_rm() {
 
     # If parsing returned with an error, output the error and return
     if [[ ! $? -eq 0 ]]; then
-      echo $dir
+      builtin echo $dir
       return 1
     fi
 
@@ -92,7 +92,7 @@ function _zulu_manpath_rm() {
       fi
     done
 
-    echo "$(_zulu_color green '✔') $dir removed from \$manpath"
+    builtin echo "$(_zulu_color green '✔') $dir removed from \$manpath"
   done
 
   # Store the new paths in the pathfile, and override $manpath
@@ -110,9 +110,9 @@ function _zulu_manpath_store() {
   separator=$'\n'
   local oldIFS=$IFS
   IFS="$separator"; out="${items[*]/#/${separator}}"
-  echo ${out:${#separator}} >! $pathfile
+  builtin echo ${out:${#separator}} >! $pathfile
   IFS=$oldIFS
-  unset oldIFS
+  builtin unset oldIFS
 }
 
 ###
@@ -120,7 +120,7 @@ function _zulu_manpath_store() {
 ###
 function _zulu_manpath_reset() {
   local separator out
-  local -a paths; paths=($(cat $pathfile))
+  local -a paths; paths=($(command cat $pathfile))
 
   typeset -gUa manpath; manpath=()
   for p in "${paths[@]}"; do
@@ -135,7 +135,7 @@ function _zulu_manpath() {
   local ctx base pathfile
 
   # Parse options
-  zparseopts -D h=help -help=help
+  builtin zparseopts -D h=help -help=help
 
   # Output help and return if requested
   if [[ -n $help ]]; then
@@ -154,7 +154,7 @@ function _zulu_manpath() {
 
   # If no context is passed, output the contents of the pathfile
   if [[ "$1" = "" ]]; then
-    cat "$pathfile"
+    command cat "$pathfile"
     return
   fi
 

--- a/src/commands/path.zsh
+++ b/src/commands/path.zsh
@@ -2,13 +2,13 @@
 # Output usage information
 ###
 function _zulu_path_usage() {
-  echo $(_zulu_color yellow "Usage:")
-  echo "  zulu path <context> <dir>"
-  echo
-  echo $(_zulu_color yellow "Context:")
-  echo "  add <dir>   Add a directory to \$path"
-  echo "  reset       Replace the current session \$path with the stored dirs"
-  echo "  rm <dir>    Remove a directory from \$path"
+  builtin echo $(_zulu_color yellow "Usage:")
+  builtin echo "  zulu path <context> <dir>"
+  builtin echo
+  builtin echo $(_zulu_color yellow "Context:")
+  builtin echo "  add <dir>   Add a directory to \$path"
+  builtin echo "  reset       Replace the current session \$path with the stored dirs"
+  builtin echo "  rm <dir>    Remove a directory from \$path"
 }
 
 ###
@@ -21,13 +21,13 @@ function _zulu_path_parse() {
   if [[ -d "$PWD/$dir" ]]; then
     # If the directory exists in the current working directory
     # convert the relative path to absolute
-    echo "$PWD/$dir"
+    builtin echo "$PWD/$dir"
   elif [[ -d "$dir" ]]; then
     # If the directory exists as an absolute path, we can use it directly
-    echo "$dir"
+    builtin echo "$dir"
   elif [[ "$check_existing" != "false" ]]; then
     # The directory could not be found
-    echo $dir
+    builtin echo $dir
     return 1
   fi
 }
@@ -37,7 +37,7 @@ function _zulu_path_parse() {
 ###
 function _zulu_path_add() {
   local dir p
-  local -a items paths; paths=($(cat $pathfile))
+  local -a items paths; paths=($(command cat $pathfile))
 
   # Check that each of the passed directories exist, and convert relative
   # paths to absolute
@@ -49,9 +49,9 @@ function _zulu_path_add() {
       # Add the directory to the array of items
       items+="$dir"
 
-      echo "$(_zulu_color green '✔') $dir added to \$path"
+      builtin echo "$(_zulu_color green '✔') $dir added to \$path"
     else
-      echo "$(_zulu_color red '✘') $dir cannot be found"
+      builtin echo "$(_zulu_color red '✘') $dir cannot be found"
     fi
 
   done
@@ -71,7 +71,7 @@ function _zulu_path_add() {
 ###
 function _zulu_path_rm() {
   local dir p
-  local -a items paths; paths=($(cat $pathfile))
+  local -a items paths; paths=($(command cat $pathfile))
 
   # Check that each of the passed directories exist, and convert relative
   # paths to absolute
@@ -80,7 +80,7 @@ function _zulu_path_rm() {
 
     # If parsing returned with an error, output the error and return
     if [[ ! $? -eq 0 ]]; then
-      echo $dir
+      builtin echo $dir
       return 1
     fi
 
@@ -92,7 +92,7 @@ function _zulu_path_rm() {
       fi
     done
 
-    echo "$(_zulu_color green '✔') $dir removed from \$path"
+    builtin echo "$(_zulu_color green '✔') $dir removed from \$path"
   done
 
   # Store the new paths in the pathfile, and override $path
@@ -110,9 +110,9 @@ function _zulu_path_store() {
   separator=$'\n'
   local oldIFS=$IFS
   IFS="$separator"; out="${items[*]/#/${separator}}"
-  echo ${out:${#separator}} >! $pathfile
+  builtin echo ${out:${#separator}} >! $pathfile
   IFS=$oldIFS
-  unset oldIFS
+  builtin unset oldIFS
 }
 
 ###
@@ -120,7 +120,7 @@ function _zulu_path_store() {
 ###
 function _zulu_path_reset() {
   local separator out
-  local -a paths; paths=($(cat $pathfile))
+  local -a paths; paths=($(command cat $pathfile))
 
   typeset -gUa path; path=()
   for p in "${paths[@]}"; do
@@ -135,7 +135,7 @@ function _zulu_path() {
   local ctx base pathfile
 
   # Parse options
-  zparseopts -D h=help -help=help
+  builtin zparseopts -D h=help -help=help
 
   # Output help and return if requested
   if [[ -n $help ]]; then
@@ -150,7 +150,7 @@ function _zulu_path() {
 
   # If no context is passed, output the contents of the pathfile
   if [[ "$1" = "" ]]; then
-    cat "$pathfile"
+    command cat "$pathfile"
     return
   fi
 

--- a/src/commands/search.zsh
+++ b/src/commands/search.zsh
@@ -2,8 +2,8 @@
 # Output usage information
 ###
 function _zulu_search_usage() {
-  echo $(_zulu_color yellow "Usage:")
-  echo "  zulu search <term>"
+  builtin echo $(_zulu_color yellow "Usage:")
+  builtin echo "  zulu search <term>"
 }
 
 ###
@@ -13,7 +13,7 @@ function _zulu_search() {
   local base index out results term=$1
 
   # Parse options
-  zparseopts -D h=help -help=help
+  builtin zparseopts -D h=help -help=help
 
   # Output help and return if requested
   if [[ -n $help ]]; then
@@ -26,6 +26,6 @@ function _zulu_search() {
   config=${ZULU_CONFIG_DIR:-"${ZDOTDIR:-$HOME}/.config/zulu"}
   index="${base}/index/packages"
 
-  results="$(zulu list --all | grep -i $term)"
-  echo "$results"
+  results="$(zulu list --all | command grep -i $term)"
+  builtin echo "$results"
 }

--- a/src/commands/self-update.zsh
+++ b/src/commands/self-update.zsh
@@ -2,12 +2,12 @@
 # Print usage information
 ###
 function _zulu_self-update_usage() {
-  echo $(_zulu_color yellow "Usage:")
-  echo "  zulu self-update [options]"
-  echo
-  echo $(_zulu_color yellow "Options:")
-  echo "  -c, --check       Check if an update is available"
-  echo "  -h, --help        Output this help text and exit"
+  builtin echo $(_zulu_color yellow "Usage:")
+  builtin echo "  zulu self-update [options]"
+  builtin echo
+  builtin echo $(_zulu_color yellow "Options:")
+  builtin echo "  -c, --check       Check if an update is available"
+  builtin echo "  -h, --help        Output this help text and exit"
 }
 
 ###
@@ -16,25 +16,25 @@ function _zulu_self-update_usage() {
 function _zulu_self-update_core() {
   local old="$(pwd)"
 
-  cd $core
-  git rebase -p --autostash FETCH_HEAD
+  builtin cd $core
+  command git rebase -p --autostash FETCH_HEAD
 
   if [[ $? -eq 0 ]]; then
-    echo "$(_zulu_color red '✗') Zulu core failed to update"
+    builtin echo "$(_zulu_color red '✗') Zulu core failed to update"
   fi
 
   [[ -f build.zsh ]] && ./build.zsh
-  source zulu
+  builtin source zulu
   _zulu_init
-  cd $old
+  builtin cd $old
 }
 
 function _zulu_self-update_check_for_update() {
   local old="$(pwd)"
 
-  cd "$base/core"
+  builtin cd "$base/core"
 
-  git fetch origin &>/dev/null
+  command git fetch origin &>/dev/null
 
   if command git rev-parse --abbrev-ref @'{u}' &>/dev/null; then
     count="$(command git rev-list --left-right --count HEAD...@'{u}' 2>/dev/null)"
@@ -42,14 +42,14 @@ function _zulu_self-update_check_for_update() {
     down="$count[(w)2]"
 
     if [[ $down -gt 0 ]]; then
-      echo "$(_zulu_color green "New Zulu version available") Run zulu self-update to upgrade"
-      cd $old
+      builtin echo "$(_zulu_color green "New Zulu version available") Run zulu self-update to upgrade"
+      builtin cd $old
       return
     fi
   fi
 
-  echo $(_zulu_color green 'No update available')
-  cd $old
+  builtin echo $(_zulu_color green 'No update available')
+  builtin cd $old
   return 1
 }
 
@@ -63,7 +63,7 @@ function _zulu_self-update() {
   core="${base}/core"
 
   # Parse options
-  zparseopts -D h=help -help=help c=check -check=check
+  builtin zparseopts -D h=help -help=help c=check -check=check
 
   # Output help and return if requested
   if [[ -n $help ]]; then
@@ -85,10 +85,10 @@ function _zulu_self-update() {
     _zulu_revolver stop
 
     if [ $? -eq 0 ]; then
-      echo "$(_zulu_color green '✔') Zulu core updated"
+      builtin echo "$(_zulu_color green '✔') Zulu core updated"
     else
-      echo "$(_zulu_color red '✘') Error updating zulu core"
-      echo "$out"
+      builtin echo "$(_zulu_color red '✘') Error updating zulu core"
+      builtin echo "$out"
 
       return 1
     fi
@@ -97,5 +97,5 @@ function _zulu_self-update() {
   fi
 
   _zulu_revolver stop
-  echo "$(_zulu_color green "No update available")"
+  builtin echo "$(_zulu_color green "No update available")"
 }

--- a/src/commands/switch.zsh
+++ b/src/commands/switch.zsh
@@ -2,12 +2,12 @@
 # Output usage information
 ###
 function _zulu_switch_usage() {
-  echo $(_zulu_color yellow "Usage:")
-  echo "  zulu switch <options> <package>"
-  echo
-  echo $(_zulu_color yellow "Options:")
-  echo "  -b, --branch <branch>   Checkout the specified branch"
-  echo "  -t, --tag <tag>         Checkout the specified tag or commit"
+  builtin echo $(_zulu_color yellow "Usage:")
+  builtin echo "  zulu switch <options> <package>"
+  builtin echo
+  builtin echo $(_zulu_color yellow "Options:")
+  builtin echo "  -b, --branch <branch>   Checkout the specified branch"
+  builtin echo "  -t, --tag <tag>         Checkout the specified tag or commit"
 }
 
 ###
@@ -18,27 +18,27 @@ function _zulu_switch_checkout() {
   local base=${ZULU_DIR:-"${ZDOTDIR:-$HOME}/.zulu"}
 
   if ! _zulu_info_is_installed $package; then
-    echo $(_zulu_color red "Package $package is not installed")
+    builtin echo $(_zulu_color red "Package $package is not installed")
   fi
 
   local oldPWD=$PWD
-  cd "$base/packages/$package"
+  builtin cd "$base/packages/$package"
 
-  git fetch origin >/dev/null 2>&1
-  output=$(git checkout -qf $ref 2>&1)
+  command git fetch origin >/dev/null 2>&1
+  output=$(command git checkout -qf $ref 2>&1)
   state=$?
 
-  cd $oldPWD
-  unset oldPWD
+  builtin cd $oldPWD
+  builtin unset oldPWD
 
   if [[ $state -ne 0 ]]; then
-    echo $(_zulu_color red "Failed to checkout $ref of package $package")
-    echo $output
+    builtin echo $(_zulu_color red "Failed to checkout $ref of package $package")
+    builtin echo $output
 
     return 1
   fi
 
-  echo "$(_zulu_color green '✔') Successfully switched $package to $ref"
+  builtin echo "$(_zulu_color green '✔') Successfully switched $package to $ref"
 }
 
 ###
@@ -48,7 +48,7 @@ function _zulu_switch() {
   local ctx base help branch tag ref
 
   # Parse options
-  zparseopts -D h=help -help=help \
+  builtin zparseopts -D h=help -help=help \
     b:=branch -branch:=branch \
     t:=tag -tag:=tag
 
@@ -59,22 +59,22 @@ function _zulu_switch() {
   fi
 
   if [[ -z $branch && -z $tag ]]; then
-    echo $(_zulu_color red 'You must specify a branch or tag')
+    builtin echo $(_zulu_color red 'You must specify a branch or tag')
     return 1
   fi
 
   if [[ -n $branch && -n $tag ]]; then
-    echo $(_zulu_color red 'You must only specify one of branch or tag')
+    builtin echo $(_zulu_color red 'You must only specify one of branch or tag')
     return 1
   fi
 
   if [[ -n $branch ]]; then
-    shift branch
+    builtin shift branch
     ref=$branch
   fi
 
   if [[ -n $tag ]]; then
-    shift tag
+    builtin shift tag
     ref=$tag
   fi
 

--- a/src/commands/sync.zsh
+++ b/src/commands/sync.zsh
@@ -2,12 +2,12 @@
 # Output usage information
 ###
 function _zulu_sync_usage() {
-  echo $(_zulu_color yellow 'Usage:')
-  echo '  zulu sync'
-  echo
-  echo $(_zulu_color yellow 'Commands:')
-  echo '  pull      Pull changes from remote repository'
-  echo '  push      Push local changes to remote repository'
+  builtin echo $(_zulu_color yellow 'Usage:')
+  builtin echo '  zulu sync'
+  builtin echo
+  builtin echo $(_zulu_color yellow 'Commands:')
+  builtin echo '  pull      Pull changes from remote repository'
+  builtin echo '  push      Push local changes to remote repository'
 }
 
 ###
@@ -15,13 +15,13 @@ function _zulu_sync_usage() {
 ###
 function _zulu_sync_pull_changes() {
   local oldPWD=$PWD
-  cd $config_dir
+  builtin cd $config_dir
 
   # Start the progress spinner
   _zulu_revolver start 'Syncing...'
 
   # Fetch from the remote
-  git fetch origin >/dev/null 2>&1
+  command git fetch origin >/dev/null 2>&1
 
   # Check if any updates are available
   count="$(command git rev-list --left-right --count HEAD...@'{u}' 2>/dev/null)"
@@ -29,22 +29,22 @@ function _zulu_sync_pull_changes() {
 
   # If no updates are available, stop and tell the user
   if [[ $down -eq 0 ]]; then
-    cd $oldPWD
-    unset oldPWD
+    builtin cd $oldPWD
+    builtin unset oldPWD
 
     _zulu_revolver stop
-    echo $(_zulu_color green 'No updates found')
+    builtin echo $(_zulu_color green 'No updates found')
     return
   fi
 
   # Rebase master over the updates
-  git rebase -p --autostash origin/master >/dev/null 2>&1
+  command git rebase -p --autostash origin/master >/dev/null 2>&1
   if [[ $? -ne 0 ]]; then
-    cd $oldPWD
-    unset oldPWD
+    builtin cd $oldPWD
+    builtin unset oldPWD
 
     _zulu_revolver stop
-    echo $(_zulu_color red 'Failed to merge changes from remote')
+    builtin echo $(_zulu_color red 'Failed to merge changes from remote')
     return 1
   fi
 
@@ -53,21 +53,21 @@ function _zulu_sync_pull_changes() {
 
   # Success! Tell the user
   _zulu_revolver stop
-  echo "$(_zulu_color green '✔') Remote changes synced"
+  builtin echo "$(_zulu_color green '✔') Remote changes synced"
 
-  cd $oldPWD
-  unset oldPWD
+  builtin cd $oldPWD
+  builtin unset oldPWD
 }
 
 function _zulu_sync_push_changes() {
   local oldPWD=$PWD
-  cd $config_dir
+  builtin cd $config_dir
 
   # Start the progress spinner
   _zulu_revolver start 'Syncing...'
 
   # Fetch from the remote
-  git fetch origin >/dev/null 2>&1
+  command git fetch origin >/dev/null 2>&1
 
   # Check if any updates are available
   count="$(command git rev-list --left-right --count HEAD...@'{u}' 2>/dev/null)"
@@ -75,33 +75,33 @@ function _zulu_sync_push_changes() {
 
   # If no updates are available, stop and tell the user
   if [[ $down -gt 0 ]]; then
-    cd $oldPWD
-    unset oldPWD
+    builtin cd $oldPWD
+    builtin unset oldPWD
 
     _zulu_revolver stop
-    echo $(_zulu_color red 'Remote has been updated. Pull changes first')
+    builtin echo $(_zulu_color red 'Remote has been updated. Pull changes first')
     return 1
   fi
 
-  dirty="$(git diff --ignore-submodules=all HEAD 2>/dev/null)"
+  dirty="$(command git diff --ignore-submodules=all HEAD 2>/dev/null)"
   if [[ -z $dirty ]]; then
-    cd $oldPWD
-    unset oldPWD
+    builtin cd $oldPWD
+    builtin unset oldPWD
 
     _zulu_revolver stop
-    echo $(_zulu_color green 'Nothing to sync')
+    builtin echo $(_zulu_color green 'Nothing to sync')
     return 1
   fi
 
-  git add . >/dev/null 2>&1
-  git commit -m "Sync config from $HOST" >/dev/null 2>&1
-  git push -u origin master >/dev/null 2>&1
+  command git add . >/dev/null 2>&1
+  command git commit -m "Sync config from $HOST" >/dev/null 2>&1
+  command git push -u origin master >/dev/null 2>&1
 
   _zulu_revolver stop
-  echo "$(_zulu_color green '✔') Local changes uploaded"
+  builtin echo "$(_zulu_color green '✔') Local changes uploaded"
 
-  cd $oldPWD
-  unset oldPWD
+  builtin cd $oldPWD
+  builtin unset oldPWD
 }
 
 ###
@@ -109,24 +109,24 @@ function _zulu_sync_push_changes() {
 ###
 function _zulu_sync_repository_exists() {
   local oldPWD=$PWD
-  cd $config_dir
+  builtin cd $config_dir
 
   # Check if the config directory is already within a git repository
   if command git rev-parse --is-inside-work-tree &>/dev/null; then
     # If it is, check if the config directory is the git root.
     # If it's not, we'll exit, since syncing is probably already
     # being handled outside of Zulu
-    git_dir=$(git rev-parse --git-dir)
+    git_dir=$(command git rev-parse --git-dir)
     if [[ $git_dir = ".git" ]]; then
-      cd $oldPWD
-      unset oldPWD
+      builtin cd $oldPWD
+      builtin unset oldPWD
 
       return 0
     fi
   fi
 
-  cd $oldPWD
-  unset oldPWD
+  builtin cd $oldPWD
+  builtin unset oldPWD
 
   return 1
 }
@@ -137,19 +137,19 @@ function _zulu_sync_repository_exists() {
 function _zulu_sync_setup() {
   # Change into the config directory
   local oldPWD=$PWD
-  cd $config_dir
+  builtin cd $config_dir
 
   # Check if the config directory is already within a git repository
   if command git rev-parse --is-inside-work-tree &>/dev/null; then
     # If it is, check if the config directory is the git root.
     # If it's not, we'll exit, since syncing is probably already
     # being handled outside of Zulu
-    git_dir=$(git rev-parse --git-dir)
+    git_dir=$(command git rev-parse --git-dir)
     if [[ $git_dir != ".git" ]]; then
-      cd $oldPWD
-      unset oldPWD
+      builtin cd $oldPWD
+      builtin unset oldPWD
 
-      echo $(_zulu_color red "It looks like $config_dir is already within a git repository at $git_dir")
+      builtin echo $(_zulu_color red "It looks like $config_dir is already within a git repository at $git_dir")
       return 1
     fi
 
@@ -157,42 +157,42 @@ function _zulu_sync_setup() {
   fi
 
   # Create a new git repository in the config directory
-  if ! git init >/dev/null 2>&1; then
-    cd $oldPWD
-    unset oldPWD
+  if ! command git init >/dev/null 2>&1; then
+    builtin cd $oldPWD
+    builtin unset oldPWD
 
-    echo $(_zulu_color red 'Failed to initialise empty repository')
+    builtin echo $(_zulu_color red 'Failed to initialise empty repository')
     exit 1
   fi
 
   # Ask the user for the remote repository URL
-  echo $(_zulu_color yellow 'Sync has not been set up yet')
-  echo 'If you haven'\''t already, create a repository using'
-  echo 'a remote service such as github.com'
-  echo
+  builtin echo $(_zulu_color yellow 'Sync has not been set up yet')
+  builtin echo 'If you haven'\''t already, create a repository using'
+  builtin echo 'a remote service such as github.com'
+  builtin echo
   vared -p "$(_zulu_color yellow 'Please enter your repository URL: ')" -c repo_url
 
   # If a URL was not provided, exit
   if [[ -z $repo_url ]]; then
-    cd $oldPWD
-    unset oldPWD
+    builtin cd $oldPWD
+    builtin unset oldPWD
 
-    echo $(_zulu_color red 'Repository URL not provided')
+    builtin echo $(_zulu_color red 'Repository URL not provided')
     return 1
   fi
 
   # Set the repository's origin to the remote
-  git remote add origin $repo_url
-  git fetch origin >/dev/null 2>&1
+  command git remote add origin $repo_url
+  command git fetch origin >/dev/null 2>&1
 
   # Create a .gitignore if one does not exist, to ensure
   # private configuration is not synced
   if [[ ! -f .gitignore ]]; then
-    echo ".backup
+    builtin echo ".backup
 *.private" > .gitignore
   fi
 
-  remotes=$(git rev-parse --remotes)
+  remotes=$(command git rev-parse --remotes)
   if [[ -n $remotes ]]; then
     # The repository provided already has a HEAD
     # Present the user with some options
@@ -212,19 +212,19 @@ Please choose from one of the following options:
       p|P )
         _zulu_revolver start 'Overwriting remote config...'
         # Commit changes
-        git add . >/dev/null 2>&1
-        git commit -m "Sync config from $HOST" >/dev/null 2>&1
+        command git add . >/dev/null 2>&1
+        command git commit -m "Sync config from $HOST" >/dev/null 2>&1
 
         # Force push to overwrite remote config
-        git push --force --set-upstream origin master >/dev/null 2>&1
+        command git push --force --set-upstream origin master >/dev/null 2>&1
 
         _zulu_revolver stop
-        echo
-        echo "$(_zulu_color green '✔') Sync setup complete"
+        builtin echo
+        builtin echo "$(_zulu_color green '✔') Sync setup complete"
 
         # Return to the previous directory
-        cd $oldPWD
-        unset oldPWD
+        builtin cd $oldPWD
+        builtin unset oldPWD
         ;;
 
       # Back up the existing config to $ZULU_CONFIG_DIR/.backup
@@ -234,38 +234,38 @@ Please choose from one of the following options:
 
         # Return to the previous directory so we can move
         # the current directory
-        cd $oldPWD
-        unset oldPWD
+        builtin cd $oldPWD
+        builtin unset oldPWD
 
         # Move existing config directory into tmp
-        mv "$ZULU_CONFIG_DIR" "/tmp/zulu-config.bkp"
+        command mv "$ZULU_CONFIG_DIR" "/tmp/zulu-config.bkp"
 
         # Since we have no local branch we can't pull
         # a remote branch into the local repository,
         # so we create a fresh clone instead
-        git clone $repo_url $ZULU_CONFIG_DIR >/dev/null 2>&1
+        command git clone $repo_url $ZULU_CONFIG_DIR >/dev/null 2>&1
 
         # Move the temporary backup back into the repository
         # so that it's easy to find. It will be ignored by git
-        mv "/tmp/zulu-config.bkp" "$ZULU_CONFIG_DIR/.backup"
+        command mv "/tmp/zulu-config.bkp" "$ZULU_CONFIG_DIR/.backup"
 
         _zulu_revolver stop
-        echo
-        echo "$(_zulu_color green '✔') Sync setup complete"
-        echo "Old config backed up to $ZULU_CONFIG_DIR/.backup"
-        echo
+        builtin echo
+        builtin echo "$(_zulu_color green '✔') Sync setup complete"
+        builtin echo "Old config backed up to $ZULU_CONFIG_DIR/.backup"
+        builtin echo
 
         zulu bundle
         zulu init
 
-        echo "$(_zulu_color green '✔') Remote changes synced"
+        builtin echo "$(_zulu_color green '✔') Remote changes synced"
         ;;
 
       # Something else was entered, exit
       * )
         # Return to the previous directory
-        cd $oldPWD
-        unset oldPWD
+        builtin cd $oldPWD
+        builtin unset oldPWD
 
         return 1
         ;;
@@ -280,7 +280,7 @@ function _zulu_sync() {
   local ctx config_dir
 
   # Parse options
-  zparseopts -D h=help -help=help
+  builtin zparseopts -D h=help -help=help
 
   # Output help and return if requested
   if [[ -n $help ]]; then
@@ -314,7 +314,7 @@ function _zulu_sync() {
       _zulu_sync_pull_changes
       ;;
     * )
-      echo $(_zulu_color red "Unrecognized command $ctx")
+      builtin echo $(_zulu_color red "Unrecognized command $ctx")
       return 1
   esac
 }

--- a/src/commands/theme.zsh
+++ b/src/commands/theme.zsh
@@ -2,8 +2,8 @@
 # Output usage information
 ###
 function _zulu_theme_usage() {
-  echo $(_zulu_color yellow "Usage:")
-  echo "  zulu theme <theme_name>"
+  builtin echo $(_zulu_color yellow "Usage:")
+  builtin echo "  zulu theme <theme_name>"
 }
 
 _zulu_theme() {
@@ -12,7 +12,7 @@ _zulu_theme() {
   theme="$1"
 
   # Parse options
-  zparseopts -D h=help -help=help
+  builtin zparseopts -D h=help -help=help
 
   # Output help and return if requested
   if [[ -n $help ]]; then
@@ -30,16 +30,16 @@ _zulu_theme() {
 
   # Test if theme prompt function exists.
   # If not, print a pretty warn message.
-  if which prompt_${theme}_setup >/dev/null 2>&1; then
+  if builtin which prompt_${theme}_setup >/dev/null 2>&1; then
     prompt ${theme}
     if [[ $? -eq 0 ]]; then
-      echo "$theme" >! $config
-      echo "$(_zulu_color green '✔') Theme set to $theme"
+      builtin echo "$theme" >! $config
+      builtin echo "$(_zulu_color green '✔') Theme set to $theme"
       return
     fi
   fi
 
-  echo $(_zulu_color red "Failed to load theme '${theme}'")
-  echo "Please ensure your theme is in \$fpath and is called prompt_${theme}_setup"
+  builtin echo $(_zulu_color red "Failed to load theme '${theme}'")
+  builtin echo "Please ensure your theme is in \$fpath and is called prompt_${theme}_setup"
   return 1
 }

--- a/src/commands/uninstall.zsh
+++ b/src/commands/uninstall.zsh
@@ -2,8 +2,8 @@
 # Output usage information
 ###
 function _zulu_uninstall_usage() {
-  echo $(_zulu_color yellow "Usage:")
-  echo "  zulu uninstall <packages...>"
+  builtin echo $(_zulu_color yellow "Usage:")
+  builtin echo "  zulu uninstall <packages...>"
 }
 
 ###
@@ -16,8 +16,8 @@ function _zulu_uninstall_package() {
 
   # Double check that the package name has been passed
   if [[ -z $package ]]; then
-    echo $(_zulu_color red "Please specify a package name")
-    echo
+    builtin echo $(_zulu_color red "Please specify a package name")
+    builtin echo
     _zulu_uninstall_usage
     return 1
   fi
@@ -30,7 +30,7 @@ function _zulu_uninstall_package() {
   # TODO: Obviously, this works, but would really like to find a pure-zsh
   #       way of doing this safely *just in case* the root variable doesn't
   #       get populated for some reason
-  rm -rf "$root"
+  command rm -rf "$root"
 
   return $?
 }
@@ -42,7 +42,7 @@ function _zulu_uninstall() {
   local base index packages out
 
   # Parse options
-  zparseopts -D h=help -help=help
+  builtin zparseopts -D h=help -help=help
 
   # Output help and return if requested
   if [[ -n $help ]]; then
@@ -57,8 +57,8 @@ function _zulu_uninstall() {
 
   # If no context is passed, output the contents of the pathfile
   if [[ "$1" = "" ]]; then
-    echo $(_zulu_color red "Please specify a package name")
-    echo
+    builtin echo $(_zulu_color red "Please specify a package name")
+    builtin echo
     _zulu_uninstall_usage
     return 1
   fi
@@ -66,12 +66,12 @@ function _zulu_uninstall() {
   # Do a first loop, to ensure all packages exist
   for package in "$@"; do
     if [[ ! -f "$index/$package" ]]; then
-      echo $(_zulu_color red "Package '$package' is not in the index")
+      builtin echo $(_zulu_color red "Package '$package' is not in the index")
       return 1
     fi
 
     if [[ ! -d "$base/packages/$package" ]]; then
-      echo $(_zulu_color red "Package '$package' is not installed")
+      builtin echo $(_zulu_color red "Package '$package' is not installed")
       return 1
     fi
   done
@@ -87,10 +87,10 @@ function _zulu_uninstall() {
     _zulu_revolver stop
 
     if [ $state -eq 0 ]; then
-      echo "$(_zulu_color green '✔') Finished uninstalling $package"
+      builtin echo "$(_zulu_color green '✔') Finished uninstalling $package"
     else
-      echo "$(_zulu_color red '✘') Error uninstalling $package"
-      echo "$out"
+      builtin echo "$(_zulu_color red '✘') Error uninstalling $package"
+      builtin echo "$out"
     fi
   done
 

--- a/src/commands/unlink.zsh
+++ b/src/commands/unlink.zsh
@@ -2,8 +2,8 @@
 # Print usage information
 ###
 function _zulu_unlink_usage() {
-  echo $(_zulu_color yellow "Usage:")
-  echo "  zulu unlink <package>"
+  builtin echo $(_zulu_color yellow "Usage:")
+  builtin echo "  zulu unlink <package>"
 }
 
 ###
@@ -13,7 +13,7 @@ function _zulu_unlink() {
   local help package json dir file link base
   local -a dirs
 
-  zparseopts -D h=help -help=help
+  builtin zparseopts -D h=help -help=help
 
   if [[ -n $help ]]; then
     _zulu_unlink_usage
@@ -29,14 +29,14 @@ function _zulu_unlink() {
   # Check if the package is already installed
   root="$base/packages/$package"
   if [[ ! -d "$root" ]]; then
-    echo $(_zulu_color red "Package '$package' is not installed")
+    builtin echo $(_zulu_color red "Package '$package' is not installed")
     return 1
   fi
 
   _zulu_revolver start "Unlinking $package..."
 
   # Get the JSON from the index
-  json=$(cat "$index/$package")
+  json=$(command cat "$index/$package")
 
   # Loop through the 'bin' and 'share' objects
   dirs=('bin' 'init' 'share')
@@ -53,16 +53,16 @@ function _zulu_unlink() {
   esac
 
   for dir in $dirs[@]; do
-    cd "$base/$dir"
+    builtin cd "$base/$dir"
     # Unlink any file in $dir which points to the package's source
     ls -la | \
-      grep "$base/packages/$package/" | \
-      awk '{print $9}' | \
-      xargs $flags rm
+      command grep "$base/packages/$package/" | \
+      command awk '{print $9}' | \
+      command xargs $flags rm
   done
 
-  cd $oldPWD
+  builtin cd $oldPWD
 
   _zulu_revolver stop
-  echo "$(_zulu_color green '✔') Finished unlinking $package"
+  builtin echo "$(_zulu_color green '✔') Finished unlinking $package"
 }

--- a/src/commands/unlink.zsh
+++ b/src/commands/unlink.zsh
@@ -55,10 +55,10 @@ function _zulu_unlink() {
   for dir in $dirs[@]; do
     builtin cd "$base/$dir"
     # Unlink any file in $dir which points to the package's source
-    ls -la | \
+    command ls -la | \
       command grep "$base/packages/$package/" | \
       command awk '{print $9}' | \
-      command xargs $flags rm
+      command xargs $flags command rm
   done
 
   builtin cd $oldPWD

--- a/src/commands/unlink.zsh
+++ b/src/commands/unlink.zsh
@@ -58,7 +58,7 @@ function _zulu_unlink() {
     command ls -la | \
       command grep "$base/packages/$package/" | \
       command awk '{print $9}' | \
-      command xargs $flags command rm
+      command xargs $flags /bin/rm
   done
 
   builtin cd $oldPWD

--- a/src/commands/update.zsh
+++ b/src/commands/update.zsh
@@ -2,12 +2,12 @@
 # Print usage information
 ###
 function _zulu_update_usage() {
-  echo $(_zulu_color yellow "Usage:")
-  echo "  zulu update [options]"
-  echo
-  echo $(_zulu_color yellow "Options:")
-  echo "  -c, --check       Check if an update is available"
-  echo "  -h, --help        Output this help text and exit"
+  builtin echo $(_zulu_color yellow "Usage:")
+  builtin echo "  zulu update [options]"
+  builtin echo
+  builtin echo $(_zulu_color yellow "Options:")
+  builtin echo "  -c, --check       Check if an update is available"
+  builtin echo "  -h, --help        Output this help text and exit"
 }
 
 ###
@@ -16,17 +16,17 @@ function _zulu_update_usage() {
 function _zulu_update_index() {
   local old="$(pwd)"
 
-  cd $index
-  git rebase -p --autostash FETCH_HEAD
-  cd $old
+  builtin cd $index
+  command git rebase -p --autostash FETCH_HEAD
+  builtin cd $old
 }
 
 function _zulu_update_check_for_update() {
   local old="$(pwd)"
 
-  cd "$base/index"
+  builtin cd "$base/index"
 
-  git fetch origin &>/dev/null
+  command git fetch origin &>/dev/null
 
   if command git rev-parse --abbrev-ref @'{u}' &>/dev/null; then
     count="$(command git rev-list --left-right --count HEAD...@'{u}' 2>/dev/null)"
@@ -34,14 +34,14 @@ function _zulu_update_check_for_update() {
     down="$count[(w)2]"
 
     if [[ $down -gt 0 ]]; then
-      echo "$(_zulu_color green "Zulu index updates available") Run zulu update to update the index"
-      cd $old
+      builtin echo "$(_zulu_color green "Zulu index updates available") Run zulu update to update the index"
+      builtin cd $old
       return
     fi
   fi
 
-  echo "$(_zulu_color green "No update available")"
-  cd $old
+  builtin echo "$(_zulu_color green "No update available")"
+  builtin cd $old
   return 1
 }
 
@@ -55,7 +55,7 @@ function _zulu_update() {
   index="${base}/index"
 
   # Parse options
-  zparseopts -D h=help -help=help c=check -check=check
+  builtin zparseopts -D h=help -help=help c=check -check=check
 
   # Output help and return if requested
   if [[ -n $help ]]; then
@@ -77,15 +77,15 @@ function _zulu_update() {
     _zulu_revolver stop
 
     if [ $? -eq 0 ]; then
-      echo "$(_zulu_color green '✔') Package index updated"
+      builtin echo "$(_zulu_color green '✔') Package index updated"
     else
-      echo "$(_zulu_color red '✘') Error updating package index"
-      echo "$out"
+      builtin echo "$(_zulu_color red '✘') Error updating package index"
+      builtin echo "$out"
     fi
 
     return
   fi
 
   _zulu_revolver stop
-  echo "$(_zulu_color green "No update available")"
+  builtin echo "$(_zulu_color green "No update available")"
 }

--- a/src/commands/upgrade.zsh
+++ b/src/commands/upgrade.zsh
@@ -2,13 +2,13 @@
 # Output usage information
 ###
 function _zulu_upgrade_usage() {
-  echo $(_zulu_color yellow "Usage:")
-  echo "  zulu upgrade [<packages...>]"
-  echo
-  echo $(_zulu_color yellow "Options:")
-  echo "  -c, --check             Check if upgrades are available"
-  echo "  -h, --help              Output this help text and exit"
-  echo "  -y, --no-confirmation   Do not ask for confirmation before upgrading"
+  builtin echo $(_zulu_color yellow "Usage:")
+  builtin echo "  zulu upgrade [<packages...>]"
+  builtin echo
+  builtin echo $(_zulu_color yellow "Options:")
+  builtin echo "  -c, --check             Check if upgrades are available"
+  builtin echo "  -h, --help              Output this help text and exit"
+  builtin echo "  -y, --no-confirmation   Do not ask for confirmation before upgrading"
 }
 
 ###
@@ -43,7 +43,7 @@ function _zulu_upgrade() {
   local -A _pids
 
   # Parse options
-  zparseopts -D h=help -help=help \
+  builtin zparseopts -D h=help -help=help \
                 c=check -check=check \
                 y=no_confirmation -no-confirmation=no_confirmation
 
@@ -129,21 +129,21 @@ function _zulu_upgrade() {
   _zulu_revolver stop
 
   if [[ ${#to_update} -eq 0 ]]; then
-    echo "$(_zulu_color green "Nothing to upgrade")"
+    builtin echo "$(_zulu_color green "Nothing to upgrade")"
     return 1
   fi
 
   if [[ -n $check ]]; then
-    echo "$(_zulu_color green 'Package upgrades available') Run zulu upgrade to upgrade"
+    builtin echo "$(_zulu_color green 'Package upgrades available') Run zulu upgrade to upgrade"
     return 0
   fi
 
-  echo $(_zulu_color yellow 'The following packages will be upgraded')
-  echo "$to_update[@]"
+  builtin echo $(_zulu_color yellow 'The following packages will be upgraded')
+  builtin echo "$to_update[@]"
 
   if [[ -z $no_confirmation ]]; then
-    echo $(_zulu_color yellow bold 'Continue (y|N)')
-    read -rs -k 1 input
+    builtin echo $(_zulu_color yellow bold 'Continue (y|N)')
+    builtin read -rs -k 1 input
   else
     input='y'
   fi
@@ -163,16 +163,16 @@ function _zulu_upgrade() {
         _zulu_revolver stop
 
         if [ $? -eq 0 ]; then
-          echo "$(_zulu_color green '✔') Finished upgrading $package"
+          builtin echo "$(_zulu_color green '✔') Finished upgrading $package"
           zulu link --no-autoselect-themes $package
         else
-          echo "$(_zulu_color red '✘') Error upgrading $package"
-          echo "$out"
+          builtin echo "$(_zulu_color red '✘') Error upgrading $package"
+          builtin echo "$out"
         fi
       done
       ;;
     *)
-      echo $(_zulu_color red 'Upgrade cancelled')
+      builtin echo $(_zulu_color red 'Upgrade cancelled')
       return 1
       ;;
   esac

--- a/src/commands/var.zsh
+++ b/src/commands/var.zsh
@@ -2,13 +2,13 @@
 # Output usage information
 ###
 function _zulu_var_usage() {
-  echo $(_zulu_color yellow "Usage:")
-  echo "  zulu var <context> [args]"
-  echo
-  echo $(_zulu_color yellow "Contexts:")
-  echo "  add <var> <command>   Add an environment variable"
-  echo "  load                  Load all environment variables from env file"
-  echo "  rm <var>              Remove an environment variable"
+  builtin echo $(_zulu_color yellow "Usage:")
+  builtin echo "  zulu var <context> [args]"
+  builtin echo
+  builtin echo $(_zulu_color yellow "Contexts:")
+  builtin echo "  add <var> <command>   Add an environment variable"
+  builtin echo "  load                  Load all environment variables from env file"
+  builtin echo "  rm <var>              Remove an environment variable"
 }
 
 ###
@@ -17,7 +17,7 @@ function _zulu_var_usage() {
 _zulu_var_add() {
   local existing var cmd private
 
-  zparseopts -D \
+  builtin zparseopts -D \
     p=private -private=private
 
   var="$1"
@@ -26,12 +26,12 @@ _zulu_var_add() {
   # Loop through each of the envfiles
   for file in $envfile $envfile.private; do
     # Search for the variable in the file
-    existing=$(cat $file | grep "export $var=")
+    existing=$(command cat $file | command grep "export $var=")
 
     # If the variable already exists in either file,
     # throw an error
     if [[ $existing != "" ]]; then
-      echo $(_zulu_color red "Environment variable '$var' already exists")
+      builtin echo $(_zulu_color red "Environment variable '$var' already exists")
       return 1
     fi
   done
@@ -42,10 +42,10 @@ _zulu_var_add() {
   fi
 
   # Save the variable to the envfile
-  echo "export $var='$cmd'" >> $envfile
+  builtin echo "export $var='$cmd'" >> $envfile
 
   # Strip any blank lines for neatness
-  echo "$(cat $envfile | grep -vE '^\s*$')" >! $envfile
+  builtin echo "$(command cat $envfile | command grep -vE '^\s*$')" >! $envfile
 
   # Reload variables
   zulu var load
@@ -63,20 +63,20 @@ _zulu_var_rm() {
   # Loop through each of the envfiles
   for file in $envfile $envfile.private; do
     # Search for the variable in the file
-    existing=$(cat $file | grep "export $var=")
+    existing=$(command cat $file | command grep "export $var=")
 
     # If we haven't found it, skip to the next file
     [[ $existing = "" ]] && continue
 
     # If we get here, we've found the variable, so we rewrite the file,
     # stripping out the definition to remove
-    echo "$(cat $file | grep -v "export $var=" | grep -vE '^\s*$')" >! $file
+    builtin echo "$(command cat $file | command grep -v "export $var=" | command grep -vE '^\s*$')" >! $file
     break
   done
 
   # The variable wasn't found in either of the envfiles, so throw an error
   if [[ $existing = "" ]]; then
-    echo $(_zulu_color red "Environment variable '$var' does not exist")
+    builtin echo $(_zulu_color red "Environment variable '$var' does not exist")
     return 1
   fi
 
@@ -89,8 +89,8 @@ _zulu_var_rm() {
 # Load vares
 ###
 _zulu_var_load() {
-  source $envfile
-  source $envfile.private
+  builtin source $envfile
+  builtin source $envfile.private
 }
 
 ###
@@ -100,7 +100,7 @@ function _zulu_var() {
   local ctx base envfile private
 
   # Parse options
-  zparseopts -D h=help -help=help \
+  builtin zparseopts -D h=help -help=help \
     p=private -private=private
 
   # Output help and return if requested
@@ -115,21 +115,21 @@ function _zulu_var() {
   envfile="${config}/env"
 
   # Check if the envfiles exist, and if not create them
-  [[ -f $envfile ]] || touch $envfile
-  [[ -f "$envfile.private" ]] || touch "$envfile.private"
+  [[ -f $envfile ]] || command touch $envfile
+  [[ -f "$envfile.private" ]] || command touch "$envfile.private"
 
   # If no context is passed, output the contents of the envfiles
   if [[ "$1" = "" ]]; then
-    cat "$envfile"
-    echo
-    echo $(_zulu_color yellow 'Private:')
-    cat "$envfile.private"
+    command cat "$envfile"
+    builtin echo
+    builtin echo $(_zulu_color yellow 'Private:')
+    command cat "$envfile.private"
     return
   fi
 
   # Get the context
   ctx="$1"
-  shift
+  builtin shift
 
   # Call the relevant function
   _zulu_var_${ctx} ${private:+'--private'} "$@"

--- a/src/helpers.zsh
+++ b/src/helpers.zsh
@@ -5,6 +5,8 @@
 ###
 function jsonval {
   local temp json=$1 key=$2
+  local oldIFS=$IFS
+  IFS=$' \t\n'
 
   temp=$(echo $json | sed 's/\\\\\//\//g' | \
     sed 's/[{}]//g' | \
@@ -16,6 +18,9 @@ function jsonval {
     sed -e 's/^ *//g' -e 's/ *$//g'
   )
   echo ${temp##*|}
+
+  IFS=$oldIFS
+  unset oldIFS
 }
 
 ###

--- a/src/helpers.zsh
+++ b/src/helpers.zsh
@@ -8,16 +8,16 @@ function jsonval {
   local oldIFS=$IFS
   IFS=$' \t\n'
 
-  temp=$(echo $json | sed 's/\\\\\//\//g' | \
-    sed 's/[{}]//g' | \
-    sed 's/\"\:\"/\|/g' | \
-    sed 's/[\,]/ /g' | \
-    sed 's/\"//g' | \
-    grep -w $key | \
-    cut -d":" -f2-9999999 | \
-    sed -e 's/^ *//g' -e 's/ *$//g'
+  temp=$(command echo $json | command sed 's/\\\\\//\//g' | \
+    command sed 's/[{}]//g' | \
+    command sed 's/\"\:\"/\|/g' | \
+    command sed 's/[\,]/ /g' | \
+    command sed 's/\"//g' | \
+    command grep -w $key | \
+    command cut -d":" -f2-9999999 | \
+    command sed -e 's/^ *//g' -e 's/ *$//g'
   )
-  echo ${temp##*|}
+  command echo ${temp##*|}
 
   IFS=$oldIFS
   unset oldIFS

--- a/src/helpers.zsh
+++ b/src/helpers.zsh
@@ -8,7 +8,7 @@ function jsonval {
   local oldIFS=$IFS
   IFS=$' \t\n'
 
-  temp=$(command echo $json | command sed 's/\\\\\//\//g' | \
+  temp=$(builtin echo $json | command sed 's/\\\\\//\//g' | \
     command sed 's/[{}]//g' | \
     command sed 's/\"\:\"/\|/g' | \
     command sed 's/[\,]/ /g' | \
@@ -17,10 +17,10 @@ function jsonval {
     command cut -d":" -f2-9999999 | \
     command sed -e 's/^ *//g' -e 's/ *$//g'
   )
-  command echo ${temp##*|}
+  builtin echo ${temp##*|}
 
   IFS=$oldIFS
-  unset oldIFS
+  builtin unset oldIFS
 }
 
 ###
@@ -28,35 +28,35 @@ function jsonval {
 # function to prevent COMMAND_NOT_FOUND errors
 ###
 function _zulu_color {
-  $(type color 2>&1 > /dev/null)
+  $(builtin type -p color 2>&1 > /dev/null)
   if [[ $? -ne 0 && ! -x ${ZULU_DIR:-"${ZDOTDIR:-$HOME}/bin/color"} ]]; then
     local color=$1 style=$2 b=0
 
-    shift
+    builtin shift
 
     case $style in
-      bold|b)           b=1; shift ;;
-      italic|i)         b=2; shift ;;
-      underline|u)      b=4; shift ;;
-      inverse|in)       b=7; shift ;;
-      strikethrough|s)  b=9; shift ;;
+      bold|b)           b=1; builtin shift ;;
+      italic|i)         b=2; builtin shift ;;
+      underline|u)      b=4; builtin shift ;;
+      inverse|in)       b=7; builtin shift ;;
+      strikethrough|s)  b=9; builtin shift ;;
     esac
 
     case $color in
-      black|b)    echo "\033[${b};30m${@}\033[0;m" ;;
-      red|r)      echo "\033[${b};31m${@}\033[0;m" ;;
-      green|g)    echo "\033[${b};32m${@}\033[0;m" ;;
-      yellow|y)   echo "\033[${b};33m${@}\033[0;m" ;;
-      blue|bl)    echo "\033[${b};34m${@}\033[0;m" ;;
-      magenta|m)  echo "\033[${b};35m${@}\033[0;m" ;;
-      cyan|c)     echo "\033[${b};36m${@}\033[0;m" ;;
-      white|w)    echo "\033[${b};37m${@}\033[0;m" ;;
+      black|b)    builtin echo "\033[${b};30m${@}\033[0;m" ;;
+      red|r)      builtin echo "\033[${b};31m${@}\033[0;m" ;;
+      green|g)    builtin echo "\033[${b};32m${@}\033[0;m" ;;
+      yellow|y)   builtin echo "\033[${b};33m${@}\033[0;m" ;;
+      blue|bl)    builtin echo "\033[${b};34m${@}\033[0;m" ;;
+      magenta|m)  builtin echo "\033[${b};35m${@}\033[0;m" ;;
+      cyan|c)     builtin echo "\033[${b};36m${@}\033[0;m" ;;
+      white|w)    builtin echo "\033[${b};37m${@}\033[0;m" ;;
     esac
 
     return
   fi
 
-  color "$@"
+  command color "$@"
 }
 
 ###
@@ -68,15 +68,15 @@ function _zulu_revolver {
     return
   fi
 
-  $(type revolver 2>&1 > /dev/null)
+  $(builtin type -p revolver 2>&1 > /dev/null)
   if [[ $? -ne 0 && ! -x ${ZULU_DIR:-"${ZDOTDIR:-$HOME}/bin/revolver"} ]]; then
     # Check for a revolver process file, and remove it if it exists.
     # Revolver will handle the missing state and kill any orphaned process.
     if [[ -f "${ZDOTDIR:-$HOME}/.revolver/${$}" ]]; then
-      rm "${ZDOTDIR:-$HOME}/.revolver/${$}"
+      command rm "${ZDOTDIR:-$HOME}/.revolver/${$}"
     fi
     return
   fi
 
-  revolver "$@"
+  command revolver "$@"
 }

--- a/src/zulu.zsh
+++ b/src/zulu.zsh
@@ -2,39 +2,39 @@
 # Print usage information
 ###
 function _zulu_usage() {
-  echo $(_zulu_color yellow "Usage:")
-  echo "  zulu [options] <command>"
-  echo
-  echo $(_zulu_color yellow "Options:")
-  echo "  -h, --help          Output this help text and exit"
-  echo "  -v, --version       Output version information and exit"
-  echo
-  echo $(_zulu_color yellow "Commands:")
-  echo "  alias <args>          Functions for adding/removing aliases"
-  echo "  bundle                Install all packages from packagefile"
-  echo "  cdpath <args>         Functions for adding/removing dirs from \$cdpath"
-  echo "  fpath <args>          Functions for adding/removing dirs from \$fpath"
-  echo "  func <args>           Functions for adding/removing functions"
-  echo "  info                  Show information for a package"
-  echo "  install <package>     Install a package"
-  echo "  link <package>        Create symlinks for a package"
-  echo "  list                  List packages"
-  echo "  manpath               Functions for adding/removing dirs from \$manpath"
-  echo "  path <args>           Functions for adding/removing dirs from \$path"
-  echo "  theme <theme>         Select a prompt theme"
-  echo "  search                Search the package index"
-  echo "  self-update           Update zulu"
-  echo "  switch                Switch to a different version of a package"
-  echo "  sync                  Sync your Zulu environment to a remote repository"
-  echo "  uninstall <package>   Uninstall a package"
-  echo "  unlink <package>      Remove symlinks for a package"
-  echo "  update                Update the package index"
-  echo "  upgrade <package>     Upgrade a package"
-  echo "  var <args>            Functions for adding/removing environment variables"
+  builtin echo $(_zulu_color yellow "Usage:")
+  builtin echo "  zulu [options] <command>"
+  builtin echo
+  builtin echo $(_zulu_color yellow "Options:")
+  builtin echo "  -h, --help          Output this help text and exit"
+  builtin echo "  -v, --version       Output version information and exit"
+  builtin echo
+  builtin echo $(_zulu_color yellow "Commands:")
+  builtin echo "  alias <args>          Functions for adding/removing aliases"
+  builtin echo "  bundle                Install all packages from packagefile"
+  builtin echo "  cdpath <args>         Functions for adding/removing dirs from \$cdpath"
+  builtin echo "  fpath <args>          Functions for adding/removing dirs from \$fpath"
+  builtin echo "  func <args>           Functions for adding/removing functions"
+  builtin echo "  info                  Show information for a package"
+  builtin echo "  install <package>     Install a package"
+  builtin echo "  link <package>        Create symlinks for a package"
+  builtin echo "  list                  List packages"
+  builtin echo "  manpath               Functions for adding/removing dirs from \$manpath"
+  builtin echo "  path <args>           Functions for adding/removing dirs from \$path"
+  builtin echo "  theme <theme>         Select a prompt theme"
+  builtin echo "  search                Search the package index"
+  builtin echo "  self-update           Update zulu"
+  builtin echo "  switch                Switch to a different version of a package"
+  builtin echo "  sync                  Sync your Zulu environment to a remote repository"
+  builtin echo "  uninstall <package>   Uninstall a package"
+  builtin echo "  unlink <package>      Remove symlinks for a package"
+  builtin echo "  update                Update the package index"
+  builtin echo "  upgrade <package>     Upgrade a package"
+  builtin echo "  var <args>            Functions for adding/removing environment variables"
 }
 
 function _zulu_version() {
-  cat "$base/core/.version"
+  command cat "$base/core/.version"
 }
 
 ###
@@ -50,7 +50,7 @@ function zulu() {
   config=${ZULU_CONFIG_DIR:-"${ZDOTDIR:-$HOME}/.config/zulu"}
 
   # Parse CLI options
-  zparseopts -D h=help -help=help v=version -version=version
+  builtin zparseopts -D h=help -help=help v=version -version=version
 
   # Print help
   if [[ -n $help ]]; then
@@ -66,28 +66,28 @@ function zulu() {
   cmd="$1"
 
   if [[ -z $cmd ]]; then
-    echo " _____         ___"
-    echo "/__  /  __  __/  /_  __"
-    echo "  / /  / / / /  / / / /"
-    echo " / /__/ /_/ /  / /_/ /"
-    echo "/____/\\____/__/\\____/"
-    echo
-    echo "Version $(zulu --version)"
-    echo
+    builtin echo " _____         ___"
+    builtin echo "/__  /  __  __/  /_  __"
+    builtin echo "  / /  / / / /  / / / /"
+    builtin echo " / /__/ /_/ /  / /_/ /"
+    builtin echo "/____/\\____/__/\\____/"
+    builtin echo
+    builtin echo "Version $(zulu --version)"
+    builtin echo
     _zulu_usage
     return
   fi
 
   # If we're in dev mode, re-source the command now
   if (( $+functions[_zulu_${cmd}] )) && [[ $ZULU_DEV_MODE -eq 1 ]]; then
-    source "$base/core/src/commands/$cmd.zsh"
+    builtin source "$base/core/src/commands/$cmd.zsh"
   fi
 
   # Check if the requested command exists
   if (( ! $+functions[_zulu_${cmd}] )); then
     # If it doesn't, print usage information and exit
-    echo $(_zulu_color red "Command '$cmd' can not be found.")
-    echo
+    builtin echo $(_zulu_color red "Command '$cmd' can not be found.")
+    builtin echo
     _zulu_usage
     return 1
   fi


### PR DESCRIPTION
It's fairly common for people to create aliases to set preferred options
for important system commands like `git`, `grep`, `ls` etc. Since Zulu relies
heavily on the default functionality of such commands, and is loaded fully
into the environment, a simple alias can have a catastrophic effect on
Zulu's functionality. To try and get around this, this commit attempts to
prefix *all* ZSH builtins and UNIX default commands.

Since the user interface of Zulu will not change, this will be released in
a patch release to fix the immediate bugs. HOWEVER, such a fundamental
change is highly likely to introduce bugs, so this will sit in Zulu Next
for a while before release to give people a chance to test it properly.

Please update this PR with any bugs/comments/feedback rather than raising
new issues.

Fix #94 