### PR TITLE
Add support for global aliases

### DIFF
--- a/src/commands/alias.zsh
+++ b/src/commands/alias.zsh
@@ -15,18 +15,25 @@ function _zulu_alias_usage() {
 # Add an alias
 ###
 function _zulu_alias_add() {
-  local existing alias cmd
+  local existing alias cmd flag
+
+  builtin zparseopts -D \
+    g=global -global=global
 
   alias="$1"
   cmd="${(@)@:2}"
 
-  existing=$(command cat $aliasfile | command grep "alias $alias=")
+  existing=$(command cat $aliasfile | command grep -E -e "^alias(\ -g)?\ $alias=")
   if [[ $existing != "" ]]; then
     builtin echo $(_zulu_color red "Alias '$alias' already exists")
     return 1
   fi
 
-  builtin echo "alias $alias='$cmd'" >> $aliasfile
+  if [[ -n $global ]]; then
+    flag=' -g'
+  fi
+
+  builtin echo "alias$flag $alias='$cmd'" >> $aliasfile
 
   zulu alias load
   builtin echo "$(_zulu_color green '✔') Alias '$alias' added"
@@ -40,13 +47,13 @@ function _zulu_alias_rm() {
 
   alias="$1"
 
-  existing=$(command cat $aliasfile | command grep "alias $alias=")
-  if [[ $existing = "" ]]; then
+  existing=$(command cat $aliasfile | command grep -E -e "^alias(\ -g)?\ $alias=")
+  if [[ -z $existing ]]; then
     builtin echo $(_zulu_color red "Alias '$alias' does not exist")
     return 1
   fi
 
-  builtin echo "$(command cat $aliasfile | command grep -v "alias $alias=")" >! $aliasfile
+  builtin echo "$(command cat $aliasfile | command grep -E -ve "^alias(\ -g)?\ $alias=")" >! $aliasfile
   unalias $alias
 
   zulu alias load

--- a/src/commands/alias.zsh
+++ b/src/commands/alias.zsh
@@ -15,7 +15,7 @@ function _zulu_alias_usage() {
 # Add an alias
 ###
 function _zulu_alias_add() {
-  local existing alias cmd flag
+  local existing alias cmd flag global
 
   builtin zparseopts -D \
     g=global -global=global

--- a/tests/commands/alias.zunit
+++ b/tests/commands/alias.zunit
@@ -6,7 +6,7 @@
   assert $state equals 0
   assert "$output" same_as "\033[0;32m✔\033[0;m Alias 'an_alias' added"
 
-  run grep -E '^alias an_alias=' tests/_support/.config/zulu/alias
+  run grep -E -e '^alias an_alias=' tests/_support/.config/zulu/alias
 
   assert $state equals 0
   assert "$output" same_as "alias an_alias='echo \"It worked\"'"
@@ -21,8 +21,49 @@
   assert "$output" same_as "\033[0;32m✔\033[0;m Alias 'an_alias' removed"
 
   local -a output
-  run grep -E '^alias an_alias=' tests/_support/.config/zulu/alias
+  run grep -E -e '^alias an_alias=' tests/_support/.config/zulu/alias
 
   assert $state equals 1
   assert "$output" is_empty
+}
+
+@test 'Test "zulu alias add -g" creates a global alias' {
+  run zulu alias add -g a_global_alias ' | cat -vte'
+
+  assert $state equals 0
+  assert "$output" same_as "\033[0;32m✔\033[0;m Alias 'a_global_alias' added"
+
+  run grep -E -e '^alias -g a_global_alias=' tests/_support/.config/zulu/alias
+
+  assert $state equals 0
+  assert "$output" same_as "alias -g a_global_alias=' | cat -vte'"
+}
+
+@test 'Test "zulu alias rm" removes a global alias' {
+  zulu alias load
+
+  run zulu alias rm 'a_global_alias'
+
+  assert $state equals 0
+  assert "$output" same_as "\033[0;32m✔\033[0;m Alias 'a_global_alias' removed"
+
+  local -a output
+  run grep -E -e '^alias -g a_global_alias=' tests/_support/.config/zulu/alias
+
+  assert $state equals 1
+  assert "$output" is_empty
+}
+
+@test 'Test "zulu alias add" does not allow overlapping standard and global aliases' {
+  run zulu alias add a_new_alias 'echo "It worked"'
+
+  assert $state equals 0
+  assert "$output" same_as "\033[0;32m✔\033[0;m Alias 'a_new_alias' added"
+
+  zulu alias load
+
+  run zulu alias add -g a_new_alias ' | cat -vte'
+
+  assert $state equals 1
+  assert "$output" same_as "\033[0;31mAlias 'a_new_alias' already exists\033[0;m"
 }


### PR DESCRIPTION
Adds `-g` and `--global` options to `zulu alias add` to define global aliases.

Fix #89

### TODO

* [x] Add tests for adding/removing global aliases
* [x] Add tests to ensure a local and global alias cannot be defined with the same name